### PR TITLE
Zeppelin dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,13 +79,19 @@
     <!--Zeppelin dependencies -->
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin</artifactId>
+      <version>0.5.0-incubating</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-zengine</artifactId>
-      <version>0.5.1-incubating-SNAPSHOT</version>
+      <version>0.5.0-incubating</version>
     </dependency>
     <dependency>		
       <groupId>org.apache.zeppelin</groupId>		
       <artifactId>zeppelin-web</artifactId>		
-      <version>0.5.1-incubating-SNAPSHOT</version>		
+      <version>0.5.0-incubating</version>		
       <type>war</type>		
     </dependency>
     <!--End of Zeppelin dependencies -->

--- a/src/main/java/se/kth/bbc/security/ua/model/BBCGroup.java
+++ b/src/main/java/se/kth/bbc/security/ua/model/BBCGroup.java
@@ -51,7 +51,7 @@ public class BBCGroup implements Serializable {
   @NotNull
   @Column(name = "gid")
   private Integer gid;
-  @JoinTable(name = "people_group",
+  @JoinTable(name = "hopsworks.people_group",
           joinColumns = {
             @JoinColumn(name = "gid",
                     referencedColumnName = "gid")},

--- a/src/main/java/se/kth/hopsworks/filters/RequestAuthFilter.java
+++ b/src/main/java/se/kth/hopsworks/filters/RequestAuthFilter.java
@@ -51,11 +51,12 @@ public class RequestAuthFilter implements ContainerRequestFilter {
     String[] pathParts = path.split("/");
     log.log(Level.INFO, "Filtering request path: {0}", pathParts[0]);
     log.log(Level.INFO, "Method called: {0}", method.getName());
-    //intercepted method must be a project operations on a specific project
-    //with an id (/project/projectId/... or /activity/projectId/...). Project creation will have time stamp so
-    //we do not need to sotre that here
+    //intercepted method must be project operations on a specific project
+    //with an id (/project/projectId/... or /activity/projectId/...). 
     if (pathParts.length > 1 && (pathParts[0].equalsIgnoreCase("project")
-            || pathParts[0].equalsIgnoreCase("activity") || pathParts[0].equalsIgnoreCase("notebook"))) {
+            || pathParts[0].equalsIgnoreCase("activity") 
+            || pathParts[0].equalsIgnoreCase("notebook")
+            || pathParts[0].equalsIgnoreCase("interpreter"))) {
 
       JsonResponse json = new JsonResponse();
       Integer projectId;

--- a/src/main/java/se/kth/hopsworks/user/model/Users.java
+++ b/src/main/java/se/kth/hopsworks/user/model/Users.java
@@ -169,7 +169,7 @@ public class Users implements Serializable {
   @NotNull
   @Column(name = "status")
   private int status;
-  @JoinTable(name = "people_group",
+  @JoinTable(name = "hopsworks.people_group",
           joinColumns = {
             @JoinColumn(name = "uid",
                     referencedColumnName = "uid")},

--- a/src/main/java/se/kth/hopsworks/zeppelin/notebook/Notebook.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/notebook/Notebook.java
@@ -389,4 +389,7 @@ public class Notebook {
     return replFactory;
   }
 
+  public void setNotebookRepo(NotebookRepo notebookRepo) {
+    this.notebookRepo = notebookRepo;
+  }
 }

--- a/src/main/java/se/kth/hopsworks/zeppelin/notebook/repo/FSNotebookRepo.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/notebook/repo/FSNotebookRepo.java
@@ -122,20 +122,33 @@ public class FSNotebookRepo implements NotebookRepo {
     for (FileObject f : rootchildren) {
       if (isDirectory(f)) {
         FileObject noteJson = f.resolveFile("note.json", NameScope.CHILD);
-        if (noteJson.exists()) {
+        if (noteJson.exists() && !listContainsNote(children, f)) {
           children.add(f);
         }
       }
     }
-
+    
     return children;
+  }
+  
+  private boolean listContainsNote(List<FileObject> list, FileObject note){
+    for (FileObject fileObj: list){
+      if (fileObj.getName().getBaseName().equals(note.getName().getBaseName())){
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
   public List<NoteInfo> list() throws IOException {
     FileObject rootDir = getRootDir();
-    FileObject projectDir = rootDir.resolveFile(this.project.getName(),
+    FileObject projectDir = null;
+    if (this.project != null) {
+      projectDir = rootDir.resolveFile(this.project.getName(),
             NameScope.CHILD);
+    }
+    
 
     LinkedList<FileObject> children = getNotes(rootDir, projectDir);
 
@@ -214,17 +227,13 @@ public class FSNotebookRepo implements NotebookRepo {
     FileObject rootDir = fsManager.resolveFile(getPath("/"));
     FileObject projectDir = rootDir.resolveFile(this.project.getName(),
             NameScope.CHILD);
-    FileObject noteDir = rootDir.resolveFile(noteId, NameScope.CHILD);
-
+    FileObject noteDir = projectDir.resolveFile(noteId, NameScope.CHILD);
+           
     if (noteDir.exists() && isDirectory(noteDir)) {
       return getNote(noteDir);
     }
 
-    if (!projectDir.exists() || !isDirectory(projectDir)) {
-      throw new IOException(projectDir.getName().toString() + " not found");
-    }
-
-    noteDir = projectDir.resolveFile(noteId, NameScope.CHILD);
+    noteDir = rootDir.resolveFile(noteId, NameScope.CHILD);
     return getNote(noteDir);
   }
 

--- a/src/main/java/se/kth/hopsworks/zeppelin/rest/InterpreterDTO.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/rest/InterpreterDTO.java
@@ -1,0 +1,70 @@
+package se.kth.hopsworks.zeppelin.rest;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+
+/**
+ *
+ * @author ermiasg
+ */
+@XmlRootElement
+public class InterpreterDTO {
+  
+  private String id;
+  private String name;
+  private String group;
+  private boolean notRunning;
+
+  public InterpreterDTO() {
+  }
+
+  public InterpreterDTO(String id, String name, String group, boolean notRunning) {
+    this.id = id;
+    this.name = name;
+    this.group = group;
+    this.notRunning = notRunning;
+  }
+  
+  public InterpreterDTO(InterpreterSetting interpreter, boolean notRunning) {
+    this.id = interpreter.id();
+    this.name = interpreter.getName();
+    this.group = interpreter.getGroup();
+    this.notRunning = notRunning;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  public boolean isNotRunning() {
+    return notRunning;
+  }
+
+  public void setNotRunning(boolean notRunning) {
+    this.notRunning = notRunning;
+  }
+
+  
+  
+  
+}

--- a/src/main/java/se/kth/hopsworks/zeppelin/rest/InterpreterRestApi.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/rest/InterpreterRestApi.java
@@ -43,21 +43,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
-import java.io.File;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.logging.Level;
 import javax.ejb.EJB;
-import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.VFS;
-import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
@@ -69,6 +58,7 @@ import se.kth.hopsworks.filters.AllowedRoles;
 import se.kth.hopsworks.rest.AppException;
 import se.kth.hopsworks.zeppelin.notebook.Notebook;
 import se.kth.hopsworks.zeppelin.server.ZeppelinSingleton;
+import se.kth.hopsworks.zeppelin.util.ZeppelinResource;
 
 /**
  * Interpreter Rest API
@@ -81,6 +71,8 @@ public class InterpreterRestApi {
   Logger logger = LoggerFactory.getLogger(InterpreterRestApi.class);
   @EJB
   private ProjectController projectController;
+  @EJB
+  private ZeppelinResource zeppelinResource;
   private final InterpreterFactory interpreterFactory;
   private final ZeppelinSingleton zeppelin = ZeppelinSingleton.SINGLETON;
 
@@ -213,7 +205,7 @@ public class InterpreterRestApi {
     Notebook newNotebook;
     Note note;
     try {
-      notebookRepo = setupNotebookRepo(project);
+      notebookRepo = zeppelinResource.setupNotebookRepo(project);
       newNotebook = new Notebook(notebookRepo);
       note = newNotebook.createNote();
     } catch (IOException | SchedulerException ex) {
@@ -257,8 +249,10 @@ public class InterpreterRestApi {
     }
 
     InterpreterSetting interpreterSetting = interpreterFactory.get(settingId);
-    //wait until the pid file is removed
-    while (!isNotRunning(interpreterSetting)) {} //too risky!
+    //wait until the peocess is stoped.
+    while (zeppelinResource.isInterpreterRunning(interpreterSetting)) {
+    }
+
     InterpreterDTO interpreter = new InterpreterDTO(interpreterSetting, true);
     return new JsonResponse(Status.OK, "", interpreter).build();
   }
@@ -272,120 +266,20 @@ public class InterpreterRestApi {
   @GET
   @Path("interpretersWithStatus")
   public Response getinterpretersWithStatus() throws AppException {
-    Map<String, InterpreterDTO> interpreters = runningInterpreters();
+    Map<String, InterpreterDTO> interpreters = null;
+    interpreters = interpreters();
     return new JsonResponse(Status.OK, "", interpreters).build();
   }
 
-  private Map<String, InterpreterDTO> runningInterpreters() throws AppException {
+  private Map<String, InterpreterDTO> interpreters() throws AppException {
     Map<String, InterpreterDTO> interpreterDTO = new HashMap<>();
     List<InterpreterSetting> interpreterSettings;
     interpreterSettings = interpreterFactory.get();
     for (InterpreterSetting interpreter : interpreterSettings) {
       interpreterDTO.put(interpreter.getGroup(), new InterpreterDTO(interpreter,
-              isNotRunning(
-                      interpreter)));
+              !zeppelinResource.isInterpreterRunning(interpreter)));
     }
     return interpreterDTO;
   }
 
-  private boolean isNotRunning(InterpreterSetting interpreter) throws
-          AppException {
-    ZeppelinConfiguration conf = this.zeppelin.getConf();
-    String binPath = conf.getRelativeDir("bin");
-    FileObject[] pidFiles = getPidFiles();
-    boolean notRunning;
-    notRunning = true;
-    for (FileObject file : pidFiles) {
-      if (file.getName().toString().contains(interpreter.getGroup())) {
-        notRunning = !isProccessAlive(binPath + "/alive.sh", readPid(file));
-        break;
-      }
-    }
-    return notRunning;
-  }
-
-  private FileObject[] getPidFiles() throws AppException {
-    ZeppelinConfiguration conf = this.zeppelin.getConf();
-    URI filesystemRoot;
-    FileSystemManager fsManager;
-    String runPath = conf.getRelativeDir("run");//the string run should be a constant.
-    try {
-      filesystemRoot = new URI(runPath);
-    } catch (URISyntaxException e1) {
-      throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
-              e1.getMessage());
-    }
-
-    if (filesystemRoot.getScheme() == null) { // it is local path
-      try {
-        filesystemRoot = new URI(new File(runPath).getAbsolutePath());
-      } catch (URISyntaxException e) {
-        throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
-                e.getMessage());
-      }
-    }
-    FileObject[] pidFiles = null;
-    try {
-      fsManager = VFS.getManager();
-      pidFiles = fsManager.resolveFile(filesystemRoot.toString() + "/").
-              getChildren();
-    } catch (FileSystemException ex) {
-      logger.error("Failed to load pid files", ex);
-    }
-    return pidFiles;
-  }
-
-  private NotebookRepo setupNotebookRepo(Project project) throws AppException {
-    ZeppelinConfiguration conf = zeppelin.getConf();
-    Class<?> notebookStorageClass;
-    NotebookRepo repo;
-    try {
-      notebookStorageClass = Class.forName(conf.getString(
-              ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_STORAGE));
-      Constructor<?> constructor = notebookStorageClass.getConstructor(
-              ZeppelinConfiguration.class, Project.class);
-      repo = (NotebookRepo) constructor.newInstance(conf, project);
-
-    } catch (ClassNotFoundException | NoSuchMethodException | SecurityException |
-            InstantiationException | IllegalAccessException |
-            IllegalArgumentException | InvocationTargetException ex) {
-      throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
-              "Could not instantiate notebook" + ex.getMessage());
-    }
-
-    return repo;
-  }
-
-  private boolean isProccessAlive(String bashPath, String pid) {
-    ProcessBuilder pb = new ProcessBuilder(bashPath, pid);
-    int exitValue;
-    try {
-      Process p = pb.start();
-      p.waitFor();
-      exitValue = p.exitValue();
-    } catch (IOException | InterruptedException ex) {
-      return false;
-    }
-    return exitValue == 0;
-  }
-
-  private String readPid(FileObject file) {
-    //pid value can only be extended up to a theoretical maximum of 
-    //32768 for 32 bit systems or 4194304 for 64 bit:
-    byte[] pid = new byte[8];
-    try {
-      file.getContent().getInputStream().read(pid);
-    } catch (FileSystemException ex) {
-      return null;
-    } catch (IOException ex) {
-      return null;
-    }
-    String s;
-    try {
-      s = new String(pid, "UTF-8").trim();
-    } catch (UnsupportedEncodingException ex) {
-      return null;
-    }
-    return s;
-  }
 }

--- a/src/main/java/se/kth/hopsworks/zeppelin/rest/NotebookRestApi.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/rest/NotebookRestApi.java
@@ -20,7 +20,21 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import javax.ejb.EJB;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import org.quartz.SchedulerException;
+import se.kth.bbc.project.Project;
+import se.kth.hopsworks.controller.ProjectController;
+import se.kth.hopsworks.controller.ResponseMessages;
+import se.kth.hopsworks.filters.AllowedRoles;
+import se.kth.hopsworks.rest.AppException;
 import se.kth.hopsworks.zeppelin.notebook.Notebook;
+import se.kth.hopsworks.zeppelin.server.ZeppelinSingleton;
 
 /**
  * Rest api endpoint for the noteBook.
@@ -31,7 +45,11 @@ public class NotebookRestApi {
 
   Logger logger = LoggerFactory.getLogger(NotebookRestApi.class);
   Gson gson = new Gson();
+  @EJB
+  private ProjectController projectController;
+  private final ZeppelinSingleton zeppelin = ZeppelinSingleton.SINGLETON;
   private final Notebook notebook;
+  private NotebookRepo notebookRepo;
 
   public NotebookRestApi() {
     this.notebook = new Notebook();
@@ -106,5 +124,106 @@ public class NotebookRestApi {
       }
     }
     return new JsonResponse(Status.OK, "", settingList).build();
+  }
+
+  /**
+   * List all Tutorial notes.
+   * <p>
+   * @return note info if successful.
+   * @throws se.kth.hopsworks.rest.AppException
+   */
+  @GET
+  public Response getTutorialNotes() throws AppException {
+    List<NoteInfo> noteInfo;
+    try {
+      notebookRepo = setupNotebookRepo(null);
+      noteInfo = notebookRepo.list();
+    } catch (IOException ex) {
+      noteInfo = null;
+      System.out.println("NNNNNNote : " + ex.getMessage());
+    }
+    return new JsonResponse(Status.OK, "", noteInfo).build();
+  }
+
+  /**
+   * List all notes in a project
+   * <p>
+   * @param id
+   * @return note info if successful.
+   * @throws se.kth.hopsworks.rest.AppException
+   */
+  @GET
+  @Path("{id}")
+  @AllowedRoles(roles = {AllowedRoles.ALL})
+  public Response getAllNotesInProject(@PathParam("id") Integer id) throws
+          AppException {
+    Project project = projectController.findProjectById(id);
+    if (project == null) {
+      throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
+              ResponseMessages.PROJECT_NOT_FOUND);
+    }
+    List<NoteInfo> noteInfos;
+    try {
+      notebookRepo = setupNotebookRepo(project);
+      noteInfos = notebookRepo.list();
+    } catch (IOException ex) {
+      noteInfos = null;
+    }
+    return new JsonResponse(Status.OK, "", noteInfos).build();
+  }
+
+  /**
+   * Create new note in a project
+   * <p>
+   * @param id
+   * @return note info if successful.
+   * @throws se.kth.hopsworks.rest.AppException
+   */
+  @GET
+  @Path("{id}/new")
+  @AllowedRoles(roles = {AllowedRoles.ALL})
+  public Response createNew(@PathParam("id") Integer id) throws
+          AppException {
+    Project project = projectController.findProjectById(id);
+    if (project == null) {
+      throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
+              ResponseMessages.PROJECT_NOT_FOUND);
+    }
+    Notebook newNotebook;
+    Note note;
+    NoteInfo noteInfo;
+    try {
+      notebookRepo = setupNotebookRepo(project);
+      newNotebook = new Notebook(notebookRepo);
+      note = newNotebook.createNote();
+      note.addParagraph(); // it's an empty note. so add one paragraph
+      note.persist();
+      noteInfo = new NoteInfo(note);
+    } catch (IOException | SchedulerException ex) {
+      throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
+              "Could not create notebook" + ex.getMessage());
+    }
+    return new JsonResponse(Status.OK, "", noteInfo).build();
+  }
+
+  private NotebookRepo setupNotebookRepo(Project project) throws AppException {
+    ZeppelinConfiguration conf = zeppelin.getConf();
+    Class<?> notebookStorageClass;
+    NotebookRepo repo;
+    try {
+      notebookStorageClass = Class.forName(conf.getString(
+              ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_STORAGE));
+      Constructor<?> constructor = notebookStorageClass.getConstructor(
+              ZeppelinConfiguration.class, Project.class);
+      repo = (NotebookRepo) constructor.newInstance(conf, project);
+
+    } catch (ClassNotFoundException | NoSuchMethodException | SecurityException |
+            InstantiationException | IllegalAccessException |
+            IllegalArgumentException | InvocationTargetException ex) {
+      throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
+              "Could not instantiate notebook" + ex.getMessage());
+    }
+
+    return repo;
   }
 }

--- a/src/main/java/se/kth/hopsworks/zeppelin/rest/NotebookRestApi.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/rest/NotebookRestApi.java
@@ -140,7 +140,6 @@ public class NotebookRestApi {
       noteInfo = notebookRepo.list();
     } catch (IOException ex) {
       noteInfo = null;
-      System.out.println("NNNNNNote : " + ex.getMessage());
     }
     return new JsonResponse(Status.OK, "", noteInfo).build();
   }

--- a/src/main/java/se/kth/hopsworks/zeppelin/server/AppScriptServlet.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/server/AppScriptServlet.java
@@ -67,9 +67,17 @@ public class AppScriptServlet extends HttpServlet {
           //this should not be hard-coded!
           if (startIndexRest >= 0 && endIndexRest >= 0) {
             String replaceStringRest
-                    = "function getRestApiBase(){ return 'http://localhost:8080/hopsworks/api'; }";
+                    = "function getRestApiBase(){  var port = Number(location.port);" +
+                      "  if (port === 'undefined' || port === 0) {" +
+                      "    port = 80;" +
+                      "    if (location.protocol === 'https:') {" +
+                      "      port = 443; } }" +
+                      "  if (port === 3333 || port === 9000) {" +
+                      "    port = 8080;" +
+                      "  }" +
+                      "  return location.protocol+'//'+location.hostname+':'+ port + '/hopsworks/api'; }";
             script.replace(startIndexRest, endIndexRest + 1, replaceStringRest);
-          }
+        }
         }
         out.println(script.toString());
 

--- a/src/main/java/se/kth/hopsworks/zeppelin/server/ReleaseZeppelinResources.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/server/ReleaseZeppelinResources.java
@@ -1,0 +1,35 @@
+package se.kth.hopsworks.zeppelin.server;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.PreDestroy;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import se.kth.hopsworks.zeppelin.notebook.Notebook;
+import se.kth.hopsworks.zeppelin.socket.NotebookServer;
+
+/**
+ *
+ * @author ermiasg
+ */
+@Startup
+@Singleton
+public class ReleaseZeppelinResources {
+  private static final Logger logger = Logger.getLogger(ReleaseZeppelinResources.class.
+          getName());
+  private final ZeppelinSingleton zeppelin = ZeppelinSingleton.SINGLETON;
+
+  public ReleaseZeppelinResources() {
+  }
+ 
+  @PreDestroy
+  void preDestroy() {
+    logger.log(Level.SEVERE, "Closing interpreters");
+    zeppelin.getReplFactory().close();
+    Notebook notebook = zeppelin.getNotebookServer().notebook();
+    notebook.setNotebookRepo(null);
+    notebook = null;
+    logger.log(Level.SEVERE, "Closed interpreters");
+
+  }
+}

--- a/src/main/java/se/kth/hopsworks/zeppelin/server/ZeppelinSingleton.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/server/ZeppelinSingleton.java
@@ -43,7 +43,7 @@ public enum ZeppelinSingleton {
       logger.log(Level.SEVERE, "Error in initializing singleton class.", e);
     }
   }
-
+  
   public ZeppelinConfiguration getConf() {
     return this.conf;
   }
@@ -68,7 +68,7 @@ public enum ZeppelinSingleton {
   public InterpreterFactory getReplFactory() {
     return this.replFactory;
   }
-
+  
   private ZeppelinConfiguration loadConfig() {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     URL url;

--- a/src/main/java/se/kth/hopsworks/zeppelin/socket/NotebookServer.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/socket/NotebookServer.java
@@ -89,7 +89,7 @@ public class NotebookServer implements
   public NotebookServer() {
   }
 
-  private Notebook notebook() {
+  public Notebook notebook() {
     return this.notebook;
   }
 

--- a/src/main/java/se/kth/hopsworks/zeppelin/socket/ZeppelinEndpointConfig.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/socket/ZeppelinEndpointConfig.java
@@ -1,10 +1,9 @@
-
 package se.kth.hopsworks.zeppelin.socket;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
@@ -15,23 +14,28 @@ import javax.websocket.server.ServerEndpointConfig;
  * @author ermiasg
  */
 public class ZeppelinEndpointConfig extends ServerEndpointConfig.Configurator {
-private static final Logger logger = Logger.getLogger(ZeppelinEndpointConfig.class.
+
+  private static final Logger logger = Logger.getLogger(
+          ZeppelinEndpointConfig.class.
           getName());
+
   @Override
   public void modifyHandshake(ServerEndpointConfig config,
           HandshakeRequest request, HandshakeResponse response) {
-    
+
     HttpSession httpSession = (HttpSession) request.getHttpSession();
-    ServletContext context = (ServletContext) httpSession.getServletContext();
     Map<String, String> cookies = new HashMap<>();
     String cookie = request.getHeaders().get("Cookie").get(0);
     String[] cookieParts = cookie.split("; ");//should have space after ;
-    for (String c : cookieParts){
-      cookies.put(c.substring(0, c.indexOf("=")), c.substring(c.indexOf("=")+1, c.length()));
+    for (String c : cookieParts) {
+      cookies.put(c.substring(0, c.indexOf("=")), c.
+              substring(c.indexOf("=") + 1, c.length()));
     }
     config.getUserProperties().put("httpSession", httpSession);
     config.getUserProperties().put("user", request.getUserPrincipal().getName());
     config.getUserProperties().put("projectID", cookies.get("projectID"));
-
+    logger.log(Level.INFO, "Connecting to zeppelin: User={0} Project id={1}",
+            new Object[]{cookies.get( "email"), cookies.get(
+                      "projectID")});
   }
 }

--- a/src/main/java/se/kth/hopsworks/zeppelin/util/ZeppelinResource.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/util/ZeppelinResource.java
@@ -1,0 +1,169 @@
+package se.kth.hopsworks.zeppelin.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ws.rs.core.Response;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import se.kth.bbc.project.Project;
+import se.kth.hopsworks.controller.ProjectController;
+import se.kth.hopsworks.rest.AppException;
+import se.kth.hopsworks.zeppelin.server.ZeppelinSingleton;
+
+/**
+ *
+ * @author ermiasg
+ */
+@Stateless
+public class ZeppelinResource {
+
+  private static final Logger LOG
+          = Logger.getLogger(ZeppelinResource.class.getName());
+
+  private final ZeppelinSingleton zeppelin = ZeppelinSingleton.SINGLETON;
+
+  public ZeppelinResource() {
+  }
+
+  /**
+   * Checks if an interpreter is running
+   * can return false if pid file reading fails. 
+   * <p>
+   * @param interpreter
+   * @return
+   */
+  public boolean isInterpreterRunning(InterpreterSetting interpreter) {
+    ZeppelinConfiguration conf = this.zeppelin.getConf();
+    String binPath = conf.getRelativeDir("bin");
+    FileObject[] pidFiles;
+    try {
+      pidFiles = getPidFiles();
+    } catch (URISyntaxException | FileSystemException ex) {
+      LOG.log(Level.SEVERE, "Could not read pid files ", ex);
+      return false;
+    }
+    boolean running = false;
+
+    for (FileObject file : pidFiles) {
+      if (file.getName().toString().contains(interpreter.getGroup())) {
+        running = isProccessAlive(binPath + "/alive.sh", readPid(file));
+        //in the rare case were there are more that one pid files for the same 
+        //interpreter break only when we find running one
+        if (running) { 
+          break;
+        }
+      }
+    }
+    return running;
+  }
+
+  private FileObject[] getPidFiles() throws URISyntaxException,
+          FileSystemException {
+    ZeppelinConfiguration conf = this.zeppelin.getConf();
+    URI filesystemRoot;
+    FileSystemManager fsManager;
+    String runPath = conf.getRelativeDir("run");//the string run should be a constant.
+    try {
+      filesystemRoot = new URI(runPath);
+    } catch (URISyntaxException e1) {
+      throw new URISyntaxException("Not a valid URI", e1.getMessage());
+    }
+
+    if (filesystemRoot.getScheme() == null) { // it is local path
+      try {
+        filesystemRoot = new URI(new File(runPath).getAbsolutePath());
+      } catch (URISyntaxException e) {
+        throw new URISyntaxException("Not a valid URI", e.getMessage());
+      }
+    }
+    FileObject[] pidFiles = null;
+    try {
+      fsManager = VFS.getManager();
+      pidFiles = fsManager.resolveFile(filesystemRoot.toString() + "/").
+              getChildren();
+    } catch (FileSystemException ex) {
+      throw new FileSystemException("Not a folder", ex.getMessage());
+    }
+    return pidFiles;
+  }
+
+  /**
+   * sets up a notebook repo for the given project.
+   * <p>
+   * @param project
+   * @return
+   */
+  public NotebookRepo setupNotebookRepo(Project project) {
+    ZeppelinConfiguration conf = zeppelin.getConf();
+    Class<?> notebookStorageClass;
+    NotebookRepo repo;
+    try {
+      notebookStorageClass = Class.forName(conf.getString(
+              ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_STORAGE));
+      Constructor<?> constructor = notebookStorageClass.getConstructor(
+              ZeppelinConfiguration.class, Project.class);
+      repo = (NotebookRepo) constructor.newInstance(conf, project);
+
+    } catch (ClassNotFoundException | NoSuchMethodException | SecurityException |
+            InstantiationException | IllegalAccessException |
+            IllegalArgumentException | InvocationTargetException ex) {
+      LOG.log(Level.SEVERE, "Could not instantiate notebook repo", ex);
+      return null;
+    }
+
+    return repo;
+  }
+
+  private boolean isProccessAlive(String bashPath, String pid) {
+    ProcessBuilder pb = new ProcessBuilder(bashPath, pid);
+    if (pid == null) {
+      return false;
+    }
+    int exitValue;
+    try {
+      Process p = pb.start();
+      p.waitFor();
+      exitValue = p.exitValue();
+    } catch (IOException | InterruptedException ex) {
+      //if the pid file exists but we can not test if it is alive then
+      //we answer true, b/c pid files are deleted when a process is killed.
+      return true;
+    }
+    return exitValue == 0;
+  }
+
+  private String readPid(FileObject file) {
+    //pid value can only be extended up to a theoretical maximum of 
+    //32768 for 32 bit systems or 4194304 for 64 bit:
+    byte[] pid = new byte[8];
+    try {
+      file.getContent().getInputStream().read(pid);
+    } catch (FileSystemException ex) {
+      return null;
+    } catch (IOException ex) {
+      return null;
+    }
+    String s;
+    try {
+      s = new String(pid, "UTF-8").trim();
+    } catch (UnsupportedEncodingException ex) {
+      return null;
+    }
+    return s;
+  }
+}

--- a/src/main/java/se/kth/rest/application/config/ApplicationConfig.java
+++ b/src/main/java/se/kth/rest/application/config/ApplicationConfig.java
@@ -13,12 +13,6 @@ public class ApplicationConfig extends ResourceConfig {
    * adding manually all the restful services of the application.
    */
   public ApplicationConfig() {
-    register(com.fasterxml.jackson.jaxrs.base.JsonMappingExceptionMapper.class);
-    register(com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper.class);
-    register(com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider.class);
-    register(com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider.class);
-    register(com.fasterxml.jackson.jaxrs.json.JsonMappingExceptionMapper.class);
-    register(com.fasterxml.jackson.jaxrs.json.JsonParseExceptionMapper.class);
     register(se.kth.hopsworks.filters.RequestAuthFilter.class);
     register(se.kth.hopsworks.rest.ActivityService.class);
     register(se.kth.hopsworks.rest.AdamService.class);

--- a/src/main/java/se/kth/rest/application/config/ApplicationConfig.java
+++ b/src/main/java/se/kth/rest/application/config/ApplicationConfig.java
@@ -26,6 +26,29 @@ public class ApplicationConfig extends Application {
    * If required, comment out calling this method in getClasses().
    */
   private void addRestResourceClasses(Set<Class<?>> resources) {
+    resources.add(com.fasterxml.jackson.jaxrs.base.JsonMappingExceptionMapper.class);
+    resources.add(com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper.class);
+    resources.add(com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider.class);
+    resources.add(com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider.class);
+    resources.add(com.fasterxml.jackson.jaxrs.json.JsonMappingExceptionMapper.class);
+    resources.add(com.fasterxml.jackson.jaxrs.json.JsonParseExceptionMapper.class);
+    resources.add(org.eclipse.persistence.jpa.rs.exceptions.JPARSExceptionMapper.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.EntityResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.MetadataResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.PersistenceResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.PersistenceUnitResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.QueryResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.SingleResultQueryResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.unversioned.EntityResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.unversioned.PersistenceResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.unversioned.PersistenceUnitResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.unversioned.QueryResource.class);
+    resources.add(org.eclipse.persistence.jpa.rs.resources.unversioned.SingleResultQueryResource.class);
+    resources.add(org.glassfish.jersey.server.mvc.internal.ViewableMessageBodyWriter.class);
+    resources.add(org.glassfish.jersey.server.oauth1.DefaultOAuth1Provider.class);
+    resources.add(org.glassfish.jersey.server.oauth1.internal.AccessTokenResource.class);
+    resources.add(org.glassfish.jersey.server.oauth1.internal.RequestTokenResource.class);
+    resources.add(org.glassfish.jersey.server.wadl.internal.WadlResource.class);
     resources.add(se.kth.hopsworks.filters.RequestAuthFilter.class);
     resources.add(se.kth.hopsworks.rest.ActivityService.class);
     resources.add(se.kth.hopsworks.rest.AdamService.class);

--- a/src/main/resources/zeppelinConf/zeppelin-site.xml
+++ b/src/main/resources/zeppelinConf/zeppelin-site.xml
@@ -47,6 +47,12 @@
 </property>
 
 <property>
+  <name>zeppelin.home</name>
+  <value>/srv/zeppelin</value>
+  <description>path for zeppelin home</description>
+</property>
+
+<property>
   <name>zeppelin.conf.dir</name>
   <value>/srv/zeppelin/conf</value>
   <description>path for config directory</description>

--- a/yo/app/index.html
+++ b/yo/app/index.html
@@ -24,6 +24,7 @@
     <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" />
     <link rel="stylesheet" href="bower_components/ng-sortable/dist/ng-sortable.css" />
     <link rel="stylesheet" href="bower_components/ng-sortable/dist/ng-sortable.style.css" />
+    <link rel="stylesheet" href="bower_components/bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->
@@ -69,11 +70,13 @@
     <script src="bower_components/Chart.js/Chart.js"></script>
     <script src="bower_components/angular-chart.js/dist/angular-chart.js"></script>
     <script src="bower_components/ng-context-menu/dist/ng-context-menu.js"></script>
-
+    <script src="bower_components/select2/select2.js"></script>
+    <script src="bower_components/angular-ui-select2/src/select2.js"></script>
     <script src="bower_components/angular-ui-select/dist/select.js"></script>
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
     <script src="bower_components/ng-sortable/dist/ng-sortable.js"></script>
+    <script src="bower_components/bootstrap-switch/dist/js/bootstrap-switch.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -82,6 +85,7 @@
     <script src="scripts/app.js"></script>
     <script src="scripts/util.js"></script>
 
+    <script src="scripts/directives/switch.js"></script>
     <script src="scripts/directives/modal.js"></script>
     <script src="scripts/directives/passwordMatch.js"></script>
 
@@ -114,6 +118,7 @@
     <script src="scripts/controllers/newJobCtrl.js"></script>
     <script src="scripts/controllers/jobDetailCtrl.js"></script>
     <script src="scripts/controllers/metadataSliderCtrl.js"></script>
+    <script src="scripts/controllers/zeppelinCtrl.js"></script>
 
     <!-- Services -->
     <script src="scripts/services/AuthInterceptorService.js"></script>
@@ -140,6 +145,7 @@
     <script src="scripts/services/JobService.js"></script>
     <script src="scripts/services/RequestService.js"></script>
     <script src="scripts/services/MetadataHelperService.js"></script>
+    <script src="scripts/services/ZeppelinService.js"></script>
     <!-- endbuild -->
 
   </body>

--- a/yo/app/index.html
+++ b/yo/app/index.html
@@ -69,8 +69,7 @@
     <script src="bower_components/Chart.js/Chart.js"></script>
     <script src="bower_components/angular-chart.js/dist/angular-chart.js"></script>
     <script src="bower_components/ng-context-menu/dist/ng-context-menu.js"></script>
-    <script src="bower_components/select2/select2.js"></script>
-    <script src="bower_components/angular-ui-select2/src/select2.js"></script>
+
     <script src="bower_components/angular-ui-select/dist/select.js"></script>
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>

--- a/yo/app/scripts/app.js
+++ b/yo/app/scripts/app.js
@@ -58,6 +58,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -120,6 +121,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -140,6 +142,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -160,6 +163,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -179,6 +183,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -198,6 +203,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -217,6 +223,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -236,6 +243,7 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
@@ -255,12 +263,33 @@ angular.module('hopsWorksApp', [
                                     },
                                     function (err) {
                                       delete $cookies.email;
+                                      delete $cookies.projectID;
                                       $location.path('/login');
                                       $location.replace();
                                       return $q.reject(err);
                                     });
                           }]
                       }
+                    })
+                    .when('/project/:projectID/zeppelin', {
+                        templateUrl: 'views/zeppelinDashboard.html',
+                        controller: 'ProjectCtrl as projectCtrl',
+                        resolve: {
+                            auth: ['$q', '$location', 'AuthService', '$cookies',
+                                function ($q, $location, AuthService, $cookies) {
+                                    return AuthService.session().then(
+                                        function (success) {
+                                            $cookies.email = success.data.data.value;
+                                        },
+                                        function (err) {
+                                            delete $cookies.email;
+                                            delete $cookies.projectID;
+                                            $location.path('/login');
+                                            $location.replace();
+                                            return $q.reject(err);
+                                        });
+                                }]
+                        }
                     })
 
                     .otherwise({

--- a/yo/app/scripts/controllers/project.js
+++ b/yo/app/scripts/controllers/project.js
@@ -156,12 +156,7 @@ angular.module('hopsWorksApp')
             };
 
             self.goToService = function (service) {
-              if (service === "Zeppelin") {
-                  window.open("http://" + $location.host() + ":" + $location.port() + "/hopsworks/zeppelin");
-              } else {
                 $location.path('project/' + self.pId + '/' + service.toLowerCase());
-              }
-
             };
 
             self.goToSpecificDataset = function (name) {

--- a/yo/app/scripts/controllers/zeppelinCtrl.js
+++ b/yo/app/scripts/controllers/zeppelinCtrl.js
@@ -1,0 +1,92 @@
+'use strict';
+
+angular.module('hopsWorksApp')
+        .controller('ZeppelinCtrl', ['$location', '$routeParams',
+          'growl', 'ModalService', 'ZeppelinService',
+          function ($location, $routeParams, growl, ModalService, ZeppelinService) {
+
+            var self = this;
+            self.interpreters = [];
+            self.tutorialNotes = [];
+            self.notes = [];
+            var projectId = $routeParams.projectID;
+
+            ZeppelinService.settings().then(function (success) {
+              for (var k in success.data.body) {
+                self.interpreters.push({setting: success.data.body[k], status: true});
+              }
+              console.log(self.interpreters);
+            }, function (error) {
+              console.log(error);
+            });
+
+            ZeppelinService.notebooks(projectId).then(function (success) {
+              self.notes = success.data.body;
+              console.log(success);
+            }, function (error) {
+              console.log(error);
+            });
+            
+            ZeppelinService.tutorialNotebooks().then(function (success) {
+              self.tutorialNotes = success.data.body;
+              console.log(success);
+            }, function (error) {
+              console.log(error);
+            });
+
+            self.changeState = function (interpreter, index) {
+              self.index = index;
+              self.interpreter = interpreter;
+              if (interpreter.status) {
+                //stop
+                toggleForwardIndeterminate(index);
+                ZeppelinService.stopInterpreter(interpreter.setting.id)
+                        .then(function (success) {
+                          toggleForwardIndeterminate(index);
+                        }, function (error) {
+                          toggleBackIndeterminate(interpreter, index);
+                          growl.error(error.data.errorMsg, {title: 'Error', ttl: 5000, referenceId: 10});
+                        });
+              } else {
+                //start
+                toggleForwardIndeterminate(index);
+                ZeppelinService.startInterpreter(interpreter.setting.id)
+                        .then(function (success) {
+                          toggleForwardIndeterminate(index);
+                        }, function (error) {
+                          toggleBackIndeterminate(interpreter, index);
+                          growl.error(error.data.errorMsg, {title: 'Error', ttl: 5000, referenceId: 10});
+                        });
+              }
+            };
+
+            self.openNote = function (note) {
+              window.open("http://localhost:8080/hopsworks/zeppelin/#/notebook/" + note.id);
+            };
+
+            self.openZeppelin = function () {
+              window.open("http://localhost:8080/hopsworks/zeppelin");
+            };
+
+            self.createNewNote = function () {
+              ZeppelinService.createNotebook(projectId).then(function (success) {
+                console.log(success);
+                self.notes.push(success.data.body);
+                growl.success("Notebook created successfully. To rename open it and double click on the name.", {title: 'Success', ttl: 5000, referenceId: 10});
+              }, function (error) {
+                growl.error(error.data.errorMsg, {title: 'Error', ttl: 5000, referenceId: 10});
+              });
+            };
+
+            var toggleForwardIndeterminate = function (index) {
+              $("input[name=" + index + "]").bootstrapSwitch('toggleIndeterminate', true);
+              $("input[name=" + index + "]").bootstrapSwitch('toggleDisabled', true);
+            };
+
+            var toggleBackIndeterminate = function (interpreter, index) {
+              $("input[name=" + index + "]").bootstrapSwitch('toggleIndeterminate', true);
+              $("input[name=" + index + "]").bootstrapSwitch('toggleDisabled', true);
+              $("input[name=" + index + "]").bootstrapSwitch('toggleState', true);
+              interpreter.status = !interpreter.status;
+            };
+          }]);

--- a/yo/app/scripts/controllers/zeppelinCtrl.js
+++ b/yo/app/scripts/controllers/zeppelinCtrl.js
@@ -1,65 +1,115 @@
 'use strict';
 
 angular.module('hopsWorksApp')
-        .controller('ZeppelinCtrl', ['$location', '$routeParams',
+        .controller('ZeppelinCtrl', ['$routeParams',
           'growl', 'ModalService', 'ZeppelinService',
-          function ($location, $routeParams, growl, ModalService, ZeppelinService) {
+          function ($routeParams, growl, ModalService, ZeppelinService) {
 
             var self = this;
             self.interpreters = [];
             self.tutorialNotes = [];
             self.notes = [];
+            self.transition = false;
             var projectId = $routeParams.projectID;
+            var statusMsgs = ['stopped    ', 'running    ', 'stopping...', 'starting...'];
 
-            ZeppelinService.settings().then(function (success) {
-              for (var k in success.data.body) {
-                self.interpreters.push({setting: success.data.body[k], status: true});
-              }
-              console.log(self.interpreters);
-            }, function (error) {
-              console.log(error);
-            });
+            var getInterpreterStatus = function () {
+              self.interpreters = [];
+              ZeppelinService.interpreters().then(function (success) {
+                for (var k in success.data.body) {
+                  self.interpreters.push({interpreter: success.data.body[k], statusMsg: statusMsgs[(success.data.body[k].notRunning ? 0 : 1)]});
+                }
+              }, function (error) {
+                console.log(error);
+              });
+            };
 
-            ZeppelinService.notebooks(projectId).then(function (success) {
-              self.notes = success.data.body;
-              console.log(success);
-            }, function (error) {
-              console.log(error);
-            });
-            
-            ZeppelinService.tutorialNotebooks().then(function (success) {
-              self.tutorialNotes = success.data.body;
-              console.log(success);
-            }, function (error) {
-              console.log(error);
-            });
+            var getNotesInProject = function () {
+              ZeppelinService.notebooks(projectId).then(function (success) {
+                self.notes = success.data.body;
+              }, function (error) {
+                console.log(error);
+              });
+            };
+
+            var getTutorialNotes = function () {
+              ZeppelinService.tutorialNotebooks().then(function (success) {
+                self.tutorialNotes = success.data.body;
+              }, function (error) {
+                console.log(error);
+              });
+            };
+
+            var refresh = function () {
+              ZeppelinService.interpreters().then(function (success) {
+                for (var i in self.interpreters) {
+                  var interpreter = success.data.body;
+                  if (self.interpreters[i].statusMsg === statusMsgs[0] || 
+                          self.interpreters[i].statusMsg === statusMsgs[1]) {
+                    self.interpreters[i].interpreter = interpreter[self.interpreters[i].interpreter.name];
+                    self.interpreters[i].statusMsg = statusMsgs[(interpreter[self.interpreters[i].interpreter.name].notRunning ? 0 : 1)];
+                  } 
+                }
+              }, function (error) {
+                console.log(error);
+              });
+            };
+
+            var init = function () {
+              getInterpreterStatus();
+              getNotesInProject();
+              getTutorialNotes();
+            };
+
+            init();
 
             self.changeState = function (interpreter, index) {
-              self.index = index;
-              self.interpreter = interpreter;
-              if (interpreter.status) {
-                //stop
+              if (!interpreter.interpreter.notRunning) {
+                //start
+                self.transition = true;
+                interpreter.statusMsg = statusMsgs[3];
                 toggleForwardIndeterminate(index);
-                ZeppelinService.stopInterpreter(interpreter.setting.id)
+                ZeppelinService.startInterpreter(projectId, interpreter.interpreter.id)
                         .then(function (success) {
                           toggleForwardIndeterminate(index);
+                          interpreter.interpreter = success.data.body;
+                          interpreter.statusMsg = statusMsgs[(success.data.body.notRunning ? 0 : 1)];
+                          self.transition = false;
                         }, function (error) {
-                          toggleBackIndeterminate(interpreter, index);
+                          toggleForwardIndeterminate(index);
+                          getInterpreterStatus();
+                          self.transition = false;
                           growl.error(error.data.errorMsg, {title: 'Error', ttl: 5000, referenceId: 10});
                         });
+
               } else {
-                //start
+                //stop
+                self.transition = true;
+                interpreter.statusMsg = statusMsgs[2];
                 toggleForwardIndeterminate(index);
-                ZeppelinService.startInterpreter(interpreter.setting.id)
+                ZeppelinService.stopInterpreter(interpreter.interpreter.id)
                         .then(function (success) {
                           toggleForwardIndeterminate(index);
+                          interpreter.interpreter = success.data.body;
+                          interpreter.statusMsg = statusMsgs[(success.data.body.notRunning ? 0 : 1)];
+                          self.transition = false;
                         }, function (error) {
-                          toggleBackIndeterminate(interpreter, index);
+                          toggleForwardIndeterminate(index);
+                          getInterpreterStatus();
+                          self.transition = false;
                           growl.error(error.data.errorMsg, {title: 'Error', ttl: 5000, referenceId: 10});
                         });
               }
             };
 
+            self.refreshInterpreters = function () {
+              refresh();
+            };
+
+            self.refreshDashboard = function () {
+              getNotesInProject();
+              //getTutorialNotes();//not nessesery b/c tutorials do not change.
+            };
             self.openNote = function (note) {
               window.open(getLocationBase() + "/zeppelin/#/notebook/" + note.id);
             };
@@ -83,10 +133,13 @@ angular.module('hopsWorksApp')
               $("input[name=" + index + "]").bootstrapSwitch('toggleDisabled', true);
             };
 
-            var toggleBackIndeterminate = function (interpreter, index) {
-              $("input[name=" + index + "]").bootstrapSwitch('toggleIndeterminate', true);
-              $("input[name=" + index + "]").bootstrapSwitch('toggleDisabled', true);
-              $("input[name=" + index + "]").bootstrapSwitch('toggleState', true);
-              interpreter.status = !interpreter.status;
+            window.onbeforeunload = function () {
+              if (!self.transition) {
+                return;
+              } else {
+                return "Are you sure you want to reload this page? You will lose any interpreter status progress.";
+              }
+
             };
+
           }]);

--- a/yo/app/scripts/controllers/zeppelinCtrl.js
+++ b/yo/app/scripts/controllers/zeppelinCtrl.js
@@ -61,11 +61,11 @@ angular.module('hopsWorksApp')
             };
 
             self.openNote = function (note) {
-              window.open("http://localhost:8080/hopsworks/zeppelin/#/notebook/" + note.id);
+              window.open(getLocationBase() + "/zeppelin/#/notebook/" + note.id);
             };
 
             self.openZeppelin = function () {
-              window.open("http://localhost:8080/hopsworks/zeppelin");
+              window.open(getLocationBase() + "/zeppelin");
             };
 
             self.createNewNote = function () {

--- a/yo/app/scripts/directives/switch.js
+++ b/yo/app/scripts/directives/switch.js
@@ -19,11 +19,19 @@ angular.module('hopsWorksApp').directive('hopsworksSwitch', function() {
             angular.element(element)
                 .bootstrapSwitch('state', model)
                 .on('switchChange.bootstrapSwitch', function(event, state) {
-                    scope.$apply(function() {
-                        ctrl.$setViewValue(state);
-                    });
+                    if(!scope.$$phase) {// check if $digest is already in progress
+                        scope.$apply(function () {
+                            ctrl.$setViewValue(state);
+                        });
+                    }
 
                 });
+            // When the model changes
+            scope.$watch(attributes.ngModel, function (newValue) {
+                if (newValue !== undefined) {
+                    element.bootstrapSwitch('state', newValue);
+                }
+            }, true);
         }
     };
 });

--- a/yo/app/scripts/directives/switch.js
+++ b/yo/app/scripts/directives/switch.js
@@ -1,0 +1,29 @@
+'use strict';
+/**
+ * This directive can be used to update ngModel value on a switch.
+ * after creating the switch element add 'hopsworks-switch' as an attribute.
+ * ng-model is required.
+ */
+angular.module('hopsWorksApp').directive('hopsworksSwitch', function() {
+    return {
+        require: 'ngModel',
+        restrict: 'A',
+        link: function(scope, element, attributes, ctrl) {
+            if (!ctrl) {
+                if (console && console.warn) {
+                    console.warn('hopsworks Switch requires ngModel to be on the element');
+                }
+                return;
+            }
+            var model = scope.$eval(attributes.ngModel);
+            angular.element(element)
+                .bootstrapSwitch('state', model)
+                .on('switchChange.bootstrapSwitch', function(event, state) {
+                    scope.$apply(function() {
+                        ctrl.$setViewValue(state);
+                    });
+
+                });
+        }
+    }
+});

--- a/yo/app/scripts/directives/switch.js
+++ b/yo/app/scripts/directives/switch.js
@@ -25,5 +25,5 @@ angular.module('hopsWorksApp').directive('hopsworksSwitch', function() {
 
                 });
         }
-    }
+    };
 });

--- a/yo/app/scripts/services/RequestInterceptorService.js
+++ b/yo/app/scripts/services/RequestInterceptorService.js
@@ -6,12 +6,12 @@ angular.module('hopsWorksApp')
             return {
               request: function (config) {
 
-                var RESOURCE_SERVER = "http://" + $location.host() + ":" + $location.port() + "/hopsworks"; 
+                var RESOURCE_SERVER = getLocationBase(); 
                 var RESOURCE_NAME = 'api';
 
                 var isApi = config.url.indexOf(RESOURCE_NAME);
 
-                if (isApi != -1) {
+                if (isApi !== -1) {
                   config.url = RESOURCE_SERVER + config.url;
                   return config || $q.when(config);
                 } else {

--- a/yo/app/scripts/services/ZeppelinService.js
+++ b/yo/app/scripts/services/ZeppelinService.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('hopsWorksApp')
+    .factory('ZeppelinService', ['$http', 'TransformRequest', function ($http, TransformRequest) {
+        return {
+            interpreters: function () {
+                return $http.get('/api/interpreter');
+            },
+            settings: function () {
+                return $http.get('/api/interpreter/setting');
+            },
+            startInterpreter: function (settingId) {
+                return $http.get('/api/interpreter/start/' + settingId);
+            },
+            stopInterpreter: function (settingId) {
+                return $http.get('/api/interpreter/stop/' + settingId);
+            },
+            notebooks: function (projectId) {
+                return $http.get('/api/notebook/'+ projectId);
+            },
+            tutorialNotebooks: function () {
+                return $http.get('/api/notebook');
+            },
+            createNotebook: function (projectId) {
+                return $http.get('/api/notebook/'+ projectId + '/new');
+            }
+
+
+        };
+    }]);
+

--- a/yo/app/scripts/services/ZeppelinService.js
+++ b/yo/app/scripts/services/ZeppelinService.js
@@ -3,14 +3,11 @@
 angular.module('hopsWorksApp')
     .factory('ZeppelinService', ['$http', 'TransformRequest', function ($http, TransformRequest) {
         return {
-            interpreters: function () {
-                return $http.get('/api/interpreter');
-            },
             settings: function () {
                 return $http.get('/api/interpreter/setting');
             },
-            startInterpreter: function (settingId) {
-                return $http.get('/api/interpreter/start/' + settingId);
+            startInterpreter: function (projectId, settingId) {
+                return $http.get('/api/interpreter/'+projectId+'/start/'+settingId);
             },
             stopInterpreter: function (settingId) {
                 return $http.get('/api/interpreter/stop/' + settingId);
@@ -23,9 +20,10 @@ angular.module('hopsWorksApp')
             },
             createNotebook: function (projectId) {
                 return $http.get('/api/notebook/'+ projectId + '/new');
+            },
+            interpreters: function () {
+                return $http.get('/api/interpreter/interpretersWithStatus');
             }
-
-
         };
     }]);
 

--- a/yo/app/scripts/util.js
+++ b/yo/app/scripts/util.js
@@ -44,3 +44,22 @@ var sortObject = function(filter, predicate, template){
   //false means 'do not reverse the order of the array'
   return filter('orderBy')(template.columns, predicate, false);
 };
+
+function getLocationBase() {
+  var port = Number(location.port);
+  if (port === 'undefined' || port === 0) {
+    port = 80;
+    if (location.protocol === 'https:') {
+      port = 443;
+    }
+  }
+
+  if (port === 3333 || port === 9000) {
+    port = 8080;
+  }
+  return location.protocol + "//" + location.hostname +":" + port + skipTrailingSlash(location.pathname);
+};
+
+function skipTrailingSlash(path) {
+  return path.slice(-1) === "/" ? path.substring(0, path.length-1) : path;
+}

--- a/yo/app/styles/style.css
+++ b/yo/app/styles/style.css
@@ -175,3 +175,7 @@ div.scroll > ul {
 div.scroll > ul > li > textarea {
   padding: 10px;
 }
+
+.glyphicon-info-sign {
+  color: royalblue;
+}

--- a/yo/app/views/zeppelinDashboard.html
+++ b/yo/app/views/zeppelinDashboard.html
@@ -1,0 +1,76 @@
+<div ng-controller="MainCtrl as mainCtrl">
+    <div ng-include="'nav.html'"></div>
+    <div id="wrapper" class="toggled">
+        <div class="overlay"></div>
+
+        <div ng-include="'navProject.html'"></div>
+
+        <section>
+            <div class="content-wrapper" ng-controller="ZeppelinCtrl as zeppelinCtrl">
+                <h3 id="projectBread" style="display: none;"> {{ projectCtrl.currentProject.projectName}} / Zeppelin Dashboard</h3>
+                <div growl reference="10" class="pull-right" ></div>
+                <div class="row" style="margin: 10px">
+                    <div class="panel col-lg-9" style="width: 74%; margin-right: 10px; min-width: 400px">
+                        <div class="panel-body">
+                            <h1>Zeppelin Dashboard</h1>
+                            <p>Here you can see notebooks in the current project and start or stop interpreters.
+                               You can go directly to note books in this project or you can <a style="text-decoration: none" ng-click="zeppelinCtrl.openZeppelin()">go to zeppelin home.</a>
+                            </p>
+                            <h3><b>Notebooks in this project</b></h3>
+                            <h4>
+                                <a style="text-decoration: none" ng-click="zeppelinCtrl.createNewNote()" href="javascript:void(0);">
+                                    <i class="glyphicon glyphicon-book" style="font-size: 15px"></i>
+                                    Create new note
+                                </a>
+                            </h4>
+                            <ul style="list-style-type: none">
+                                <li ng-repeat="note in zeppelinCtrl.notes track by $index">
+                                    <a ng-click="zeppelinCtrl.openNote(note)" style="text-decoration: none">
+                                    <i class="glyphicon glyphicon-file" style="font-size: 10px"></i>
+                                    {{note.name || 'Note ' + note.id}}</a>
+                                </li>
+                            </ul>
+                            <h3><b>Tutorial Notebooks</b></h3>
+                            <ul style="list-style-type: none">
+                                <li ng-repeat="note in zeppelinCtrl.tutorialNotes track by $index">
+                                    <a ng-click="zeppelinCtrl.openNote(note)" style="text-decoration: none">
+                                    <i class="glyphicon glyphicon-file" style="font-size: 10px"></i>
+                                    {{note.name || 'Note ' + note.id}}</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="panel col-lg-2" style="width: 25%; min-width: 300px">
+                        <div class="panel-body">
+                            <h2>Interpreters</h2>
+
+                            <table class="table table-hover" style="width: 100%">
+                                <tr ng-repeat="interpreter in zeppelinCtrl.interpreters track by $index">
+                                    <td><span>{{interpreter.setting.group}} Interpreter </span></td>
+                                    <td style="text-align: right">
+                                        <input type="checkbox"
+                                               id="switch-{{$index}}"
+                                               name="switch-{{$index}}"
+                                               data-size="mini"
+                                               data-on-text="Start"
+                                               data-off-text="Stop"
+                                               data-on-color="success"
+                                               data-off-color="danger"
+                                               ng-model="interpreter.status"
+                                               data-indeterminate="false"
+                                               ng-change="zeppelinCtrl.changeState(interpreter, 'switch-'+ $index)"
+                                               hopsworks-switch>
+                                    </td>
+                                </tr>
+                            </table>
+
+                        </div>
+                        <hr>
+                        <p style="line-height: 1.02; margin-top: 10px"><span class="glyphicon glyphicon-info-sign" ></span>  If CPU quota is enforced starting too many interpreters can eat up your quota. Running a paragraph in a notebook will automatically start the necessary interpreters for that job.     </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+</div>

--- a/yo/app/views/zeppelinDashboard.html
+++ b/yo/app/views/zeppelinDashboard.html
@@ -82,7 +82,7 @@
 
                         </div>
                         <hr>
-                        <p style="line-height: 1.02; margin-top: 10px"><span class="glyphicon glyphicon-info-sign" ></span>  If CPU quota is enforced starting too many interpreters can eat up your quota. Running a paragraph in a notebook will automatically start the necessary interpreters for that job.     </p>
+                        <p style="line-height: 1.02; margin-top: 10px"><span class="glyphicon glyphicon-info-sign" ></span>  Running a paragraph in a notebook will automatically start the necessary interpreters for that job.  </p>
                     </div>
                 </div>
             </div>

--- a/yo/app/views/zeppelinDashboard.html
+++ b/yo/app/views/zeppelinDashboard.html
@@ -10,7 +10,14 @@
                 <h3 id="projectBread" style="display: none;"> {{ projectCtrl.currentProject.projectName}} / Zeppelin Dashboard</h3>
                 <div growl reference="10" class="pull-right" ></div>
                 <div class="row" style="margin: 10px">
-                    <div class="panel col-lg-9" style="width: 74%; margin-right: 10px; min-width: 400px">
+                    <div class="panel col-lg-9" style="width: 69%; margin-right: 10px; min-width: 400px">
+                       <a 
+                          tooltip="Refresh Panel" 
+                          class="pull-right" 
+                          style="padding-top: 10px; color: #c1c2c3"
+                          ng-click="zeppelinCtrl.refreshDashboard()">
+                            <span class="glyphicon glyphicon-refresh"></span>
+                        </a>
                         <div class="panel-body">
                             <h1>Zeppelin Dashboard</h1>
                             <p>Here you can see notebooks in the current project and start or stop interpreters.
@@ -41,13 +48,21 @@
                         </div>
                     </div>
 
-                    <div class="panel col-lg-2" style="width: 25%; min-width: 300px">
+                    <div class="panel col-lg-2" style="width: 30%; min-width: 400px">
+                        <a 
+                          tooltip="Refresh Panel" 
+                          class="pull-right" 
+                          style="padding-top: 10px; color: #c1c2c3"
+                          ng-click="zeppelinCtrl.refreshInterpreters()">
+                            <span class="glyphicon glyphicon-refresh"></span>
+                        </a>
                         <div class="panel-body">
                             <h2>Interpreters</h2>
 
                             <table class="table table-hover" style="width: 100%">
                                 <tr ng-repeat="interpreter in zeppelinCtrl.interpreters track by $index">
-                                    <td><span>{{interpreter.setting.group}} Interpreter </span></td>
+                                    <td><span>{{interpreter.interpreter.group}} Interpreter </span></td>
+                                    <td class="text-muted">{{interpreter.statusMsg}}</td>
                                     <td style="text-align: right">
                                         <input type="checkbox"
                                                id="switch-{{$index}}"
@@ -57,7 +72,7 @@
                                                data-off-text="Stop"
                                                data-on-color="success"
                                                data-off-color="danger"
-                                               ng-model="interpreter.status"
+                                               ng-model="interpreter.interpreter.notRunning"
                                                data-indeterminate="false"
                                                ng-change="zeppelinCtrl.changeState(interpreter, 'switch-'+ $index)"
                                                hopsworks-switch>

--- a/yo/bower.json
+++ b/yo/bower.json
@@ -22,7 +22,8 @@
     "angular-ui-select2": "~0.0.5",
     "angular-ui-select": "~0.12.0",
     "eonasdan-bootstrap-datetimepicker": "~4.14.30",
-    "ng-sortable": "1.3.0"
+    "ng-sortable": "1.3.0",
+    "bootstrap-switch": "~3.3.2"
   },
   "devDependencies": {
     "angular-mocks": "1.3.16"

--- a/yo/test/karma.conf.js
+++ b/yo/test/karma.conf.js
@@ -44,6 +44,7 @@ module.exports = function (config) {
       'bower_components/moment/moment.js',
       'bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
       'bower_components/ng-sortable/dist/ng-sortable.js',
+      'bower_components/bootstrap-switch/dist/js/bootstrap-switch.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
       'app/scripts/**/*.js',


### PR DESCRIPTION
1.  Show notebooks in different category 
  * project specific and
  * tutorial
2.  Start and stop interpreters - needs bash file that tests if a process is alive to be added to                                                                                                      /srv/zeppelin/bin 
3.  Close all open interpreters on undeploy.
4.  Change localhost to location in the front-end to support access via ip address.
5.   Changed zeppelin dependency from 0.5.1-incubating-SNAPSHOT to 0.5.0-incubating b/c 0.5.0-incubating is now in apache repo.

Problem
When starting an interpreter a temporary notebook is created, this notebook can some times end up in the project even if it is deleted after star-up is completed.  