### PR TITLE
Hack

### DIFF
--- a/src/main/java/io/hops/hdfs/HdfsLeDescriptorsFacade.java
+++ b/src/main/java/io/hops/hdfs/HdfsLeDescriptorsFacade.java
@@ -44,5 +44,16 @@ public class HdfsLeDescriptorsFacade extends AbstractFacade<HdfsLeDescriptors> {
             return null;
         }
     }
+    /**
+     * 
+     * @return "ip:port" for the first namenode found in the table.
+     */
+    public String getSingleEndpoint() {
+      HdfsLeDescriptors hdfs = findEndpoint();
+      if (hdfs == null) {
+        return "";
+      }
+      return hdfs.getHostname();
+    }
     
 }

--- a/src/main/java/se/kth/bbc/fileoperations/ErasureCodeJob.java
+++ b/src/main/java/se/kth/bbc/fileoperations/ErasureCodeJob.java
@@ -20,9 +20,10 @@ public class ErasureCodeJob extends HopsJob {
   
   private ErasureCodeJobConfiguration jobConfig;
 
-  public ErasureCodeJob(JobDescription job, AsynchronousJobExecutor services, Users user, String hadoopDir) {
+  public ErasureCodeJob(JobDescription job, AsynchronousJobExecutor services, Users user, 
+      String hadoopDir, String nameNodeIpPort) {
 
-    super(job, services, user, hadoopDir);
+    super(job, services, user, hadoopDir, nameNodeIpPort);
 
     if (!(job.getJobConfig() instanceof ErasureCodeJobConfiguration)) {
       throw new IllegalArgumentException(

--- a/src/main/java/se/kth/bbc/jobs/adam/AdamJob.java
+++ b/src/main/java/se/kth/bbc/jobs/adam/AdamJob.java
@@ -28,8 +28,8 @@ public class AdamJob extends YarnJob {
 
   public AdamJob(JobDescription job,
       AsynchronousJobExecutor services, Users user, String hadoopDir, String sparkDir,
-      String adamJarPath) {
-    super(job, services, user, hadoopDir);
+      String nameNodeIpPort, String adamJarPath) {
+    super(job, services, user, hadoopDir, nameNodeIpPort);
     if (!(job.getJobConfig() instanceof AdamJobConfiguration)) {
       throw new IllegalArgumentException(
           "JobDescription must contain a AdamJobConfiguration object. Received: "
@@ -129,7 +129,7 @@ public class AdamJob extends YarnJob {
 
     try {
       runner = builder.getYarnRunner(jobDescription.getProject().getName(), user.getUsername(),
-          hadoopDir, sparkDir);
+          hadoopDir, sparkDir, nameNodeIpPort);
     } catch (IOException e) {
       logger.log(Level.SEVERE,
           "Failed to create YarnRunner.", e);

--- a/src/main/java/se/kth/bbc/jobs/cuneiform/CuneiformJob.java
+++ b/src/main/java/se/kth/bbc/jobs/cuneiform/CuneiformJob.java
@@ -58,8 +58,9 @@ public final class CuneiformJob extends YarnJob {
    * contain a CuneiformJobConfiguration object.
    */
   public CuneiformJob(JobDescription job,
-          AsynchronousJobExecutor services, Users user, String hadoopDir, String sparkDir, String hiwayDir) {
-    super(job, services, user, hadoopDir);
+          AsynchronousJobExecutor services, Users user, String hadoopDir, String sparkDir, String hiwayDir,
+          String nameNodeIpPort) {
+    super(job, services, user, hadoopDir, nameNodeIpPort);
     if (!(job.getJobConfig() instanceof CuneiformJobConfiguration)) {
       throw new IllegalArgumentException(
               "The jobconfiguration in JobDescription must be of type CuneiformJobDescription. Received: "
@@ -192,7 +193,7 @@ public final class CuneiformJob extends YarnJob {
 
     try {
       //Get the YarnRunner instance
-      runner = b.build(hadoopDir, sparkDir);
+      runner = b.build(hadoopDir, sparkDir, nameNodeIpPort);
     } catch (IOException ex) {
       logger.log(Level.SEVERE,
               "Unable to create temp directory for logs.",

--- a/src/main/java/se/kth/bbc/jobs/execution/HopsJob.java
+++ b/src/main/java/se/kth/bbc/jobs/execution/HopsJob.java
@@ -47,6 +47,7 @@ public abstract class HopsJob {
   protected final JobDescription jobDescription;
   protected final Users user;
   protected final String hadoopDir;
+  protected final String nameNodeIpPort;
   protected final UserGroupInformation hdfsUser;
 
   /**
@@ -60,7 +61,8 @@ public abstract class HopsJob {
    * @throws NullPointerException If either of the given arguments is null.
    */
   protected HopsJob(JobDescription jobDescription,
-          AsynchronousJobExecutor services, Users user, String hadoopDir) throws
+          AsynchronousJobExecutor services, Users user, String hadoopDir,
+          String nameNodeIpPort) throws
           NullPointerException {
     //Check validity
     if (jobDescription == null) {
@@ -75,6 +77,7 @@ public abstract class HopsJob {
     this.services = services;
     this.user = user;
     this.hadoopDir = hadoopDir;
+    this.nameNodeIpPort = nameNodeIpPort;
     try {
       //if HopsJob is created in a doAs UserGroupInformation.getCurrentUser()
       //will return the proxy user, if not it will return the superuser.  

--- a/src/main/java/se/kth/bbc/jobs/spark/SparkJob.java
+++ b/src/main/java/se/kth/bbc/jobs/spark/SparkJob.java
@@ -36,8 +36,8 @@ public final class SparkJob extends YarnJob {
    */
   public SparkJob(JobDescription job, AsynchronousJobExecutor services,
       Users user, final String hadoopDir,
-      final String sparkDir, String sparkUser) {
-    super(job, services, user, hadoopDir);
+      final String sparkDir, final String nameNodeIpPort, String sparkUser) {
+    super(job, services, user, hadoopDir, nameNodeIpPort);
     if (!(job.getJobConfig() instanceof SparkJobConfiguration)) {
       throw new IllegalArgumentException(
           "JobDescription must contain a SparkJobConfiguration object. Received: "
@@ -72,7 +72,7 @@ public final class SparkJob extends YarnJob {
     try {
       runner = runnerbuilder.
           getYarnRunner(jobDescription.getProject().getName(),
-              sparkUser, hadoopDir, sparkDir);
+              sparkUser, hadoopDir, sparkDir, nameNodeIpPort);
 
     } catch (IOException e) {
       logger.log(Level.SEVERE,

--- a/src/main/java/se/kth/bbc/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/src/main/java/se/kth/bbc/jobs/spark/SparkYarnRunnerBuilder.java
@@ -56,12 +56,12 @@ public class SparkYarnRunnerBuilder {
    * @param sparkUser
    * @param hadoopDir
    * @param sparkDir
+   * @param nameNodeIpPort
    * @return The YarnRunner instance to launch the Spark job on Yarn.
    * @throws IOException If creation failed.
    */
   public YarnRunner getYarnRunner(String project, String sparkUser,
-          final String hadoopDir,
-          final String sparkDir)
+          final String hadoopDir, final String sparkDir, final String nameNodeIpPort)
           throws IOException {
 
     String sparkClasspath = Settings.getSparkDefaultClasspath(sparkDir);
@@ -140,7 +140,7 @@ public class SparkYarnRunnerBuilder {
     //Set app name
     builder.appName(jobName);
 
-    return builder.build(hadoopDir, sparkDir);
+    return builder.build(hadoopDir, sparkDir, nameNodeIpPort);
   }
 
   public SparkYarnRunnerBuilder setJobName(String jobName) {

--- a/src/main/java/se/kth/bbc/jobs/yarn/YarnJob.java
+++ b/src/main/java/se/kth/bbc/jobs/yarn/YarnJob.java
@@ -50,8 +50,8 @@ public abstract class YarnJob extends HopsJob {
    * YarnJobConfiguration object.
    */
   public YarnJob(JobDescription job, AsynchronousJobExecutor services,
-          Users user, String hadoopDir) {
-    super(job, services, user, hadoopDir);
+          Users user, String hadoopDir, String nameNodeIpPort) {
+    super(job, services, user, hadoopDir, nameNodeIpPort);
     if (!(job.getJobConfig() instanceof YarnJobConfiguration)) {
       throw new IllegalArgumentException(
               "JobDescription must contain a YarnJobConfiguration object. Received class: "

--- a/src/main/java/se/kth/bbc/jobs/yarn/YarnRunner.java
+++ b/src/main/java/se/kth/bbc/jobs/yarn/YarnRunner.java
@@ -45,7 +45,7 @@ import se.kth.hopsworks.util.Settings;
 public class YarnRunner {
 
   private static final Logger logger = Logger.getLogger(YarnRunner.class.
-          getName());
+      getName());
   public static final String APPID_PLACEHOLDER = "$APPID";
   private static final String APPID_REGEX = "\\$APPID";
   private static final String KEY_CLASSPATH = "CLASSPATH";
@@ -76,8 +76,8 @@ public class YarnRunner {
   private final List<String> filesToRemove;
   private String hadoopDir;
   private String sparkDir;
+  private String nameNodeIpPort;
 
-  
   private boolean readyToSubmit = false;
   private ApplicationSubmissionContext appContext;
 
@@ -89,8 +89,7 @@ public class YarnRunner {
    * <p/>
    * @return The received ApplicationId identifying the application.
    * @throws YarnException
-   * @throws IOException Can occur upon opening and moving execution and input
-   * files.
+   * @throws IOException Can occur upon opening and moving execution and input files.
    */
   public YarnMonitor startAppMaster() throws YarnException, IOException {
     logger.info("Starting application master.");
@@ -112,7 +111,7 @@ public class YarnRunner {
     appContext.setApplicationType("Hops Yarn");
 
     //Add local resources to AM container
-    Map<String, LocalResource> localResources = addAllToLocalResources();
+    Map<String, LocalResource> localResources = addAllToLocalResources(nameNodeIpPort);
 
     //Copy files to HDFS that are expected to be there
     copyAllToHDFS();
@@ -128,7 +127,7 @@ public class YarnRunner {
     //TODO: set up security tokens
     //Set up container launch context
     ContainerLaunchContext amContainer = ContainerLaunchContext.newInstance(
-            localResources, env, amCommands, null, null, null);
+        localResources, env, amCommands, null, null, null);
     // TODO: implement this for real. doAs
     //    UserGroupInformation proxyUser = UserGroupInformation.
     //            createProxyUser("user", UserGroupInformation.
@@ -148,9 +147,7 @@ public class YarnRunner {
     }
 
     //And submit
-    logger.
-            log(Level.INFO,
-                    "Submitting application {0} to applications manager.", appId);
+    logger.log(Level.INFO, "Submitting application {0} to applications manager.", appId);
     yarnClient.submitApplication(appContext);
 
     yarnClient.close();
@@ -174,9 +171,8 @@ public class YarnRunner {
   //--------------------------- CALLBACK METHODS ------------------------------
   //---------------------------------------------------------------------------
   /**
-   * Get the ApplicationSubmissionContext used to submit the app. This method
-   * should only be called from registered Commands. Invoking it before the
-   * ApplicationSubmissionContext is properly set up will result in an
+   * Get the ApplicationSubmissionContext used to submit the app. This method should only be called from registered
+   * Commands. Invoking it before the ApplicationSubmissionContext is properly set up will result in an
    * IllegalStateException.
    * <p/>
    * @return
@@ -184,7 +180,7 @@ public class YarnRunner {
   public ApplicationSubmissionContext getAppContext() {
     if (!readyToSubmit) {
       throw new IllegalStateException(
-              "ApplicationSubmissionContext cannot be requested before it is set up.");
+          "ApplicationSubmissionContext cannot be requested before it is set up.");
     }
     return appContext;
   }
@@ -211,27 +207,27 @@ public class YarnRunner {
     int maxMem = appResponse.getMaximumResourceCapability().getMemory();
     if (amMemory > maxMem) {
       logger.log(Level.WARNING,
-              "AM memory specified above max threshold of cluster. Using max value. Specified: {0}, max: {1}",
-              new Object[]{amMemory,
-                maxMem});
+          "AM memory specified above max threshold of cluster. Using max value. Specified: {0}, max: {1}",
+          new Object[]{amMemory,
+            maxMem});
       amMemory = maxMem;
     }
     int maxVcores = appResponse.getMaximumResourceCapability().getVirtualCores();
     if (amVCores > maxVcores) {
       logger.log(Level.WARNING,
-              "AM vcores specified above max threshold of cluster. Using max value. Specified: {0}, max: {1}",
-              new Object[]{amVCores,
-                maxVcores});
+          "AM vcores specified above max threshold of cluster. Using max value. Specified: {0}, max: {1}",
+          new Object[]{amVCores,
+            maxVcores});
       amVCores = maxVcores;
     }
   }
 
-  private Map<String, LocalResource> addAllToLocalResources() throws IOException {
+  private Map<String, LocalResource> addAllToLocalResources(String nameNodeIpPort) throws IOException {
     Map<String, LocalResource> localResources = new HashMap<>();
     //If an AM jar has been specified: include that one
     if (shouldCopyAmJarToLocalResources && amJarLocalName != null
-            && !amJarLocalName.isEmpty() && amJarPath != null
-            && !amJarPath.isEmpty()) {
+        && !amJarLocalName.isEmpty() && amJarPath != null
+        && !amJarPath.isEmpty()) {
       if (amJarPath.startsWith("hdfs")) {
         amLocalResourcesOnHDFS.put(amJarLocalName, amJarPath);
       } else {
@@ -252,29 +248,29 @@ public class YarnRunner {
       Path dst = new Path(basePath + File.separator + filename);
       fs.copyFromLocalFile(new Path(source), dst);
       logger.log(Level.INFO, "Copying from: {0} to: {1}",
-              new Object[]{source,
-                dst});
+          new Object[]{source,
+            dst});
       FileStatus scFileStat = fs.getFileStatus(dst);
       LocalResource scRsrc = LocalResource.newInstance(ConverterUtils.
-              getYarnUrlFromPath(dst),
-              LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
-              scFileStat.getLen(),
-              scFileStat.getModificationTime());
+          getYarnUrlFromPath(dst),
+          LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
+          scFileStat.getLen(),
+          scFileStat.getModificationTime());
       localResources.put(key, scRsrc);
     }
     //For all local resources with hdfs path: add local resource
     for (Entry<String, String> entry : amLocalResourcesOnHDFS.entrySet()) {
       String key = entry.getKey();
       String pathToResource = entry.getValue();
-	    pathToResource = pathToResource.replaceFirst("hdfs:/*Projects",
-			"hdfs://10.33.67.25:8020/Projects");      
+      pathToResource = pathToResource.replaceFirst("hdfs:/*Projects",
+          "hdfs://" + nameNodeIpPort + "/Projects");
       Path src = new Path(pathToResource);
       FileStatus scFileStat = fs.getFileStatus(src);
       LocalResource scRsrc = LocalResource.newInstance(ConverterUtils.
-              getYarnUrlFromPath(src),
-              LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
-              scFileStat.getLen(),
-              scFileStat.getModificationTime());
+          getYarnUrlFromPath(src),
+          LocalResourceType.FILE, LocalResourceVisibility.PUBLIC,
+          scFileStat.getLen(),
+          scFileStat.getModificationTime());
       localResources.put(key, scRsrc);
     }
     return localResources;
@@ -302,15 +298,13 @@ public class YarnRunner {
         Path[] srcs = FileUtil.stat2Paths(fs.globStatus(srcPath), srcPath);
         if (srcs.length > 1 && !fs.isDirectory(dst)) {
           throw new IOException("When copying multiple files, "
-                  + "destination should be a directory.");
+              + "destination should be a directory.");
         }
         for (Path src1 : srcs) {
           FileUtil.copy(fs, src1, fs, dst, false, conf);
         }
       }
-      logger.log(Level.INFO, "Copying from: {0} to: {1}",
-              new Object[]{path,
-                dst});
+      logger.log(Level.INFO, "Copying from: {0} to: {1}", new Object[]{path, dst});
     }
   }
 
@@ -318,8 +312,8 @@ public class YarnRunner {
     // Add AppMaster.jar location to classpath
     StringBuilder classPathEnv = new StringBuilder().append("./*");
     for (String c : conf.getStrings(
-            YarnConfiguration.YARN_APPLICATION_CLASSPATH,
-            YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH)) {
+        YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+        YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH)) {
       classPathEnv.append(":").append(c.trim());
     }
     classPathEnv.append(":").append("./log4j.properties");
@@ -338,7 +332,7 @@ public class YarnRunner {
     }
     //Put some environment vars in env
     env.
-            put(Settings.HADOOP_COMMON_HOME_KEY, hadoopDir);
+        put(Settings.HADOOP_COMMON_HOME_KEY, hadoopDir);
 //                    Settings.HADOOP_COMMON_HOME_VALUE);
     env.put(Settings.HADOOP_CONF_DIR_KEY, Settings.getHadoopConfDir(hadoopDir));
 //    env.put(Settings.HADOOP_CONF_DIR_KEY, Settings.HADOOP_CONF_DIR_VALUE);
@@ -377,7 +371,7 @@ public class YarnRunner {
       amcommand.append(str).append(" ");
     }
     logger.log(Level.INFO, "Completed setting up app master command: {0}",
-            amcommand.toString());
+        amcommand.toString());
     List<String> amCommands = new ArrayList<>();
     amCommands.add(amcommand.toString());
     return amCommands;
@@ -413,7 +407,7 @@ public class YarnRunner {
     this.yarnClient = builder.yarnClient;
     this.conf = builder.conf;
     this.shouldCopyAmJarToLocalResources
-            = builder.shouldAddAmJarToLocalResources;
+        = builder.shouldAddAmJarToLocalResources;
     this.filesToBeCopied = builder.filesToBeCopied;
     this.logPathsAreHdfs = builder.logPathsAreRelativeToResources;
     this.stdOutPath = builder.stdOutPath;
@@ -423,6 +417,7 @@ public class YarnRunner {
     this.filesToRemove = builder.filesToRemove;
     this.hadoopDir = builder.hadoopDir;
     this.sparkDir = builder.sparkDir;
+    this.nameNodeIpPort = builder.nameNodeIpPort;
   }
 
   //---------------------------------------------------------------------------
@@ -518,6 +513,7 @@ public class YarnRunner {
 
     private String hadoopDir;
     private String sparkDir;
+    private String nameNodeIpPort;
 
     //Constructors
     public Builder(String amMainClass) {
@@ -588,9 +584,8 @@ public class YarnRunner {
     }
 
     /**
-     * Set the configuration of the Yarn Application to the values contained in
-     * the YarnJobConfiguration object. This overrides any defaults or
-     * previously set values contained in the config file.
+     * Set the configuration of the Yarn Application to the values contained in the YarnJobConfiguration object. This
+     * overrides any defaults or previously set values contained in the config file.
      * <p/>
      * @param config
      * @return
@@ -607,9 +602,8 @@ public class YarnRunner {
     }
 
     /**
-     * Set a file to be copied over to HDFS. It will be copied to
-     * localresourcesBasePath/filename and the original will be removed.
-     * Equivalent to addFileToBeCopied(path,true).
+     * Set a file to be copied over to HDFS. It will be copied to localresourcesBasePath/filename and the original will
+     * be removed. Equivalent to addFileToBeCopied(path,true).
      * <p/>
      * @param path
      * @return
@@ -619,9 +613,8 @@ public class YarnRunner {
     }
 
     /**
-     * Set a file to be copied over to HDFS. It will be copied to
-     * localresourcesBasePath/filename. If removeAfterCopy is true, the file
-     * will also be removed after copying.
+     * Set a file to be copied over to HDFS. It will be copied to localresourcesBasePath/filename. If removeAfterCopy is
+     * true, the file will also be removed after copying.
      * <p/>
      * @param path
      * @param removeAfterCopy
@@ -663,10 +656,8 @@ public class YarnRunner {
     }
 
     /**
-     * Set the base path for local resources for the application master.
-     * This is the path where the AM expects its local resources to be. Use
-     * "$APPID" as a replacement for the appId, which will be replaced once
-     * it is available.
+     * Set the base path for local resources for the application master. This is the path where the AM expects its local
+     * resources to be. Use "$APPID" as a replacement for the appId, which will be replaced once it is available.
      * <p/>
      * If this method is not invoked, a default path will be used.
      *
@@ -686,15 +677,12 @@ public class YarnRunner {
     }
 
     /**
-     * Add a local resource that should be added to the AM container. The
-     * name is the key as used in the LocalResources map passed to the
-     * container. The source is the local path to the file. The file will be
-     * copied into HDFS under the path
-     * <i>localResourcesBasePath</i>/<i>filename</i> and the source file will be
-     * removed.
+     * Add a local resource that should be added to the AM container. The name is the key as used in the LocalResources
+     * map passed to the container. The source is the local path to the file. The file will be copied into HDFS under
+     * the path
+     * <i>localResourcesBasePath</i>/<i>filename</i> and the source file will be removed.
      *
-     * @param name The name of the local resource, key in the local resource
-     * map.
+     * @param name The name of the local resource, key in the local resource map.
      * @param source The local path to the file.
      * @return
      */
@@ -703,12 +691,11 @@ public class YarnRunner {
     }
 
     /**
-     * Add a local resource that should be added to the AM container. The
-     * name is the key as used in the LocalResources map passed to the
-     * container. The source is the local path to the file. The file will be
-     * copied into HDFS under the path
-     * <i>localResourcesBasePath</i>/<i>filename</i> and if removeAfterCopy is
-     * true, the original will be removed after starting the AM.
+     * Add a local resource that should be added to the AM container. The name is the key as used in the LocalResources
+     * map passed to the container. The source is the local path to the file. The file will be copied into HDFS under
+     * the path
+     * <i>localResourcesBasePath</i>/<i>filename</i> and if removeAfterCopy is true, the original will be removed after
+     * starting the AM.
      * <p/>
      * @param name
      * @param source
@@ -716,7 +703,7 @@ public class YarnRunner {
      * @return
      */
     public Builder addLocalResource(String name, String source,
-            boolean removeAfterCopy) {
+        boolean removeAfterCopy) {
       if (source.startsWith("hdfs")) {
         amLocalResourcesOnHDFS.put(name, source);
       } else {
@@ -739,9 +726,8 @@ public class YarnRunner {
     }
 
     /**
-     * Add a Command that should be executed before submission of the
-     * application to the ResourceManager. The commands will be executed in
-     * order of addition.
+     * Add a Command that should be executed before submission of the application to the ResourceManager. The commands
+     * will be executed in order of addition.
      * <p/>
      * @param c
      * @return
@@ -752,9 +738,8 @@ public class YarnRunner {
     }
 
     /**
-     * Add a java option that will be added in the invocation of the java
-     * command. Should be provided in a form that is accepted by the java
-     * command, i.e. including a dash in the beginning etc.
+     * Add a java option that will be added in the invocation of the java command. Should be provided in a form that is
+     * accepted by the java command, i.e. including a dash in the beginning etc.
      * <p/>
      * @param option
      * @return
@@ -770,15 +755,13 @@ public class YarnRunner {
      * @param hadoopDir
      * @param sparkDir
      * @return
-     * @throws IllegalStateException Thrown if (a) configuration is not found,
-     * (b) invalid main class name
-     * @throws IOException Thrown if stdOut and/or stdErr path have not been set
-     * and temp files could not be created
+     * @throws IllegalStateException Thrown if (a) configuration is not found, (b) invalid main class name
+     * @throws IOException Thrown if stdOut and/or stdErr path have not been set and temp files could not be created
      */
-    public YarnRunner build(String hadoopDir, String sparkDir) throws IllegalStateException, IOException {
+    public YarnRunner build(String hadoopDir, String sparkDir, String nameNodeIpPort) throws IllegalStateException, IOException {
       //Set configuration
       try {
-        setConfiguration(hadoopDir, sparkDir);
+        setConfiguration(hadoopDir, sparkDir, nameNodeIpPort);
       } catch (IllegalStateException e) {
         throw new IllegalStateException("Failed to load configuration", e);
       }
@@ -792,7 +775,7 @@ public class YarnRunner {
         amMainClass = getMainClassNameFromJar();
         if (amMainClass == null) {
           throw new IllegalStateException(
-                  "Could not infer main class name from jar and was not specified.");
+              "Could not infer main class name from jar and was not specified.");
         }
       }
       //Default localResourcesBasePath
@@ -817,15 +800,16 @@ public class YarnRunner {
       return new YarnRunner(this);
     }
 
-    private void setConfiguration(String hadoopDir, String sparkDir) throws IllegalStateException {
+    private void setConfiguration(String hadoopDir, String sparkDir, String nameNodeIpPort)
+        throws IllegalStateException {
       //Get the path to the Yarn configuration file from environment variables
       String yarnConfDir = System.getenv(Settings.ENV_KEY_YARN_CONF_DIR);
 //      If not found in environment variables: warn and use default,
       if (yarnConfDir == null) {
         logger.log(Level.WARNING,
-                "Environment variable "
-                + Settings.ENV_KEY_YARN_CONF_DIR +
-                " not found, using settings: {0}", Settings.getYarnConfDir(hadoopDir));
+            "Environment variable "
+            + Settings.ENV_KEY_YARN_CONF_DIR
+            + " not found, using settings: {0}", Settings.getYarnConfDir(hadoopDir));
         yarnConfDir = Settings.getYarnConfDir(hadoopDir);
 
       }
@@ -833,14 +817,15 @@ public class YarnRunner {
       //Get the configuration file at found path
       this.hadoopDir = hadoopDir;
       this.sparkDir = sparkDir;
+      this.nameNodeIpPort = nameNodeIpPort;
 
       Path confPath = new Path(yarnConfDir);
       File confFile = new File(confPath + File.separator
-              + Settings.DEFAULT_YARN_CONFFILE_NAME);
+          + Settings.DEFAULT_YARN_CONFFILE_NAME);
       if (!confFile.exists()) {
         logger.log(Level.SEVERE,
-                "Unable to locate Yarn configuration file in {0}. Aborting exectution.",
-                confFile);
+            "Unable to locate Yarn configuration file in {0}. Aborting exectution.",
+            confFile);
         throw new IllegalStateException("No Yarn conf file");
       }
 
@@ -850,8 +835,8 @@ public class YarnRunner {
       if (hadoopConfDir == null) {
         logger.log(Level.WARNING,
             "Environment variable "
-                + Settings.ENV_KEY_HADOOP_CONF_DIR
-                + " not found, using default {0}", 
+            + Settings.ENV_KEY_HADOOP_CONF_DIR
+            + " not found, using default {0}",
             (hadoopDir + "/" + Settings.HADOOP_CONF_RELATIVE_DIR));
         hadoopConfDir = hadoopDir + "/" + Settings.HADOOP_CONF_RELATIVE_DIR;
       }
@@ -859,8 +844,8 @@ public class YarnRunner {
       File hadoopConf = new File(confPath + "/" + Settings.DEFAULT_HADOOP_CONFFILE_NAME);
       if (!hadoopConf.exists()) {
         logger.log(Level.SEVERE,
-                "Unable to locate Hadoop configuration file in {0}. Aborting exectution.",
-                hadoopConf);
+            "Unable to locate Hadoop configuration file in {0}. Aborting exectution.",
+            hadoopConf);
         throw new IllegalStateException("No Hadoop conf file");
       }
 
@@ -868,8 +853,8 @@ public class YarnRunner {
       File hdfsConf = new File(confPath + "/" + Settings.DEFAULT_HDFS_CONFFILE_NAME);
       if (!hdfsConf.exists()) {
         logger.log(Level.SEVERE,
-                "Unable to locate HDFS configuration file in {0}. Aborting exectution.",
-                hdfsConf);
+            "Unable to locate HDFS configuration file in {0}. Aborting exectution.",
+            hdfsConf);
         throw new IllegalStateException("No HDFS conf file");
       }
 
@@ -909,7 +894,7 @@ public class YarnRunner {
     private String getMainClassNameFromJar() {
       if (amJarPath == null) {
         throw new IllegalStateException(
-                "Main class name and amJar path cannot both be null.");
+            "Main class name and amJar path cannot both be null.");
       }
       String fileName = amJarPath;
       String mainClassName = null;
@@ -921,7 +906,7 @@ public class YarnRunner {
         }
       } catch (IOException io) {
         logger.log(Level.SEVERE, "Could not open jar file " + amJarPath
-                + " to load main class.", io);
+            + " to load main class.", io);
         return null;
       }
 

--- a/src/main/java/se/kth/bbc/jobs/yarn/YarnRunner.java
+++ b/src/main/java/se/kth/bbc/jobs/yarn/YarnRunner.java
@@ -265,7 +265,10 @@ public class YarnRunner {
     //For all local resources with hdfs path: add local resource
     for (Entry<String, String> entry : amLocalResourcesOnHDFS.entrySet()) {
       String key = entry.getKey();
-      Path src = new Path(entry.getValue());
+      String pathToResource = entry.getValue();
+	    pathToResource = pathToResource.replaceFirst("hdfs:/*Projects",
+			"hdfs://10.33.67.25:8020/Projects");      
+      Path src = new Path(pathToResource);
       FileStatus scFileStat = fs.getFileStatus(src);
       LocalResource scRsrc = LocalResource.newInstance(ConverterUtils.
               getYarnUrlFromPath(src),

--- a/src/main/java/se/kth/bbc/security/ua/PasswordValidator.java
+++ b/src/main/java/se/kth/bbc/security/ua/PasswordValidator.java
@@ -15,7 +15,7 @@ import se.kth.bbc.security.auth.AccountStatusErrorMessages;
 @FacesValidator("passwordValidator")
 public class PasswordValidator implements Validator {
 
-  final String PASSWORD_PATTERNN = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{6,}$";
+  final String PASSWORD_PATTERN = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{6,}$";
 
   /**
    * Ensure the password presented by user during registration is qualified.
@@ -78,7 +78,7 @@ public class PasswordValidator implements Validator {
    * @return
    */
   public boolean isAlphaNumeric(String s) {
-    Pattern pattern = Pattern.compile(PASSWORD_PATTERNN);
+    Pattern pattern = Pattern.compile(PASSWORD_PATTERN);
     Matcher matcher = pattern.matcher(s);
     return matcher.matches();
   }

--- a/src/main/java/se/kth/bbc/security/ua/PeopleAdministration.java
+++ b/src/main/java/se/kth/bbc/security/ua/PeopleAdministration.java
@@ -418,8 +418,9 @@ public class PeopleAdministration implements Serializable {
 
       userTransaction.begin();
 
-      if (!"#".equals(sgroup) && (!sgroup.isEmpty() || sgroup != null)) {
-        userManager.registerGroup(user1, BBCGroup.valueOf(sgroup).getValue());
+//      if (!"#".equals(sgroup) && (!sgroup.isEmpty() || sgroup != null)) {
+//        userManager.registerGroup(user1, BBCGroup.valueOf(sgroup).getValue());
+        userManager.registerGroup(user1, BBCGroup.BBC_RESEARCHER.getValue());
         userManager.registerGroup(user1, BBCGroup.BBC_USER.getValue());
         
         auditManager.registerRoleChange(sessionState.getLoggedInUser(), RolesAuditActions.ADDROLE.name(),
@@ -430,13 +431,13 @@ public class PeopleAdministration implements Serializable {
                 RolesAuditActions.SUCCESS.name(), BBCGroup.BBC_GUEST.name(),
                 user1);
           
-      } else {
-          auditManager.registerAccountChange(sessionState.getLoggedInUser(),
-              PeopleAccountStatus.ACCOUNT_ACTIVATED.name(),
-              RolesAuditActions.FAILED.name(), "Role could not be granted.", user1);
-        MessagesController.addSecurityErrorMessage("Role could not be granted.");
-        return;
-      }
+//      } else {
+//          auditManager.registerAccountChange(sessionState.getLoggedInUser(),
+//              PeopleAccountStatus.ACCOUNT_ACTIVATED.name(),
+//              RolesAuditActions.FAILED.name(), "Role could not be granted.", user1);
+//        MessagesController.addSecurityErrorMessage("Role could not be granted.");
+//        return;
+//      }
 
       userManager.updateStatus(user1, PeopleAccountStatus.ACCOUNT_ACTIVATED.
               getValue());

--- a/src/main/java/se/kth/hopsworks/controller/AdamController.java
+++ b/src/main/java/se/kth/hopsworks/controller/AdamController.java
@@ -1,5 +1,6 @@
 package se.kth.hopsworks.controller;
 
+import io.hops.hdfs.HdfsLeDescriptorsFacade;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,6 +37,8 @@ public class AdamController {
   private SparkController sparkController;
   @EJB
   private Settings settings;
+  @EJB
+  private HdfsLeDescriptorsFacade hdfsEndpoint;
 
   /**
    * Start an execution of the given job, ordered by the given User.
@@ -66,6 +69,7 @@ public class AdamController {
     }
     //Get to starting the job
     AdamJob adamjob = new AdamJob(job, submitter, user, settings.getHadoopDir(), settings.getSparkDir(),
+        hdfsEndpoint.getSingleEndpoint(),
         settings.getAdamJarHdfsPath());
     Execution jh = adamjob.requestExecutionId();
     if (jh != null) {

--- a/src/main/java/se/kth/hopsworks/controller/CuneiformController.java
+++ b/src/main/java/se/kth/hopsworks/controller/CuneiformController.java
@@ -1,6 +1,7 @@
 package se.kth.hopsworks.controller;
 
 import de.huberlin.wbi.cuneiform.core.semanticmodel.HasFailedException;
+import io.hops.hdfs.HdfsLeDescriptorsFacade;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,6 +37,8 @@ public class CuneiformController {
   private ActivityFacade activities;
   @EJB
   private Settings settings;
+  @EJB
+  private HdfsLeDescriptorsFacade hdfsEndpoint;
 
   /**
    * Inspect the workflow at the given path under the projectname. The path
@@ -96,8 +99,9 @@ public class CuneiformController {
     }
 
     //Then: create a CuneiformJob to run it
-    CuneiformJob cfjob = new CuneiformJob(job, submitter, user, settings.getHadoopDir(), settings.getSparkDir(),
-    settings.getHiwayDir());
+    CuneiformJob cfjob = new CuneiformJob(job, submitter, user, settings.getHadoopDir(), 
+        settings.getSparkDir(), hdfsEndpoint.getSingleEndpoint(),
+        settings.getHiwayDir());
     Execution jh = cfjob.requestExecutionId();
     if (jh != null) {
       submitter.startExecution(cfjob);

--- a/src/main/java/se/kth/hopsworks/controller/SparkController.java
+++ b/src/main/java/se/kth/hopsworks/controller/SparkController.java
@@ -90,7 +90,7 @@ public class SparkController {
 		@Override
 		public SparkJob run() throws Exception {
 		  return new SparkJob(job, submitter, user, settings.
-				  getHadoopDir(), settings.getSparkDir(),
+				  getHadoopDir(), settings.getSparkDir(), hdfsLeDescriptorsFacade.getSingleEndpoint(),
 				  settings.getSparkUser());
 		}
 	  });
@@ -129,7 +129,7 @@ public class SparkController {
 	}
 
 	SparkJob sparkjob = new SparkJob(job, submitter, user, settings.getHadoopDir(), settings.getSparkDir(),
-			settings.getSparkUser());
+      hdfsLeDescriptorsFacade.getSingleEndpoint(), settings.getSparkUser());
 
 	submitter.stopExecution(sparkjob, appid);
 

--- a/src/main/java/se/kth/hopsworks/controller/UserValidator.java
+++ b/src/main/java/se/kth/hopsworks/controller/UserValidator.java
@@ -15,7 +15,7 @@ import se.kth.hopsworks.rest.AppException;
 public class UserValidator {
 
   public static final int PASSWORD_MIN_LENGTH = 6;
-  public static final int PASSWORD_MAX_LENGTH = 13;
+  public static final int PASSWORD_MAX_LENGTH = 255;
   private static final String PASSWORD_PATTERN
           = "(?=.*[a-z])(?=.*[A-Z])(?=.*[\\d\\W]).*$";
   private static final String EMAIL_PATTERN

--- a/src/main/java/se/kth/hopsworks/controller/UserValidator.java
+++ b/src/main/java/se/kth/hopsworks/controller/UserValidator.java
@@ -15,7 +15,7 @@ import se.kth.hopsworks.rest.AppException;
 public class UserValidator {
 
   public static final int PASSWORD_MIN_LENGTH = 6;
-  public static final int PASSWORD_MAX_LENGTH = 10;
+  public static final int PASSWORD_MAX_LENGTH = 13;
   private static final String PASSWORD_PATTERN
           = "(?=.*[a-z])(?=.*[A-Z])(?=.*[\\d\\W]).*$";
   private static final String EMAIL_PATTERN

--- a/src/main/java/se/kth/hopsworks/rest/DataSetService.java
+++ b/src/main/java/se/kth/hopsworks/rest/DataSetService.java
@@ -1,5 +1,6 @@
 package se.kth.hopsworks.rest;
 
+import io.hops.hdfs.HdfsLeDescriptorsFacade;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -107,6 +108,8 @@ public class DataSetService {
   private Settings settings;
   @Inject
   private DownloadService downloader;
+  @EJB
+  private HdfsLeDescriptorsFacade hdfsLeDescriptorsFacade;
 
   
   private Integer projectId;
@@ -673,7 +676,7 @@ public class DataSetService {
     System.out.println("job persisted in the database");
     //instantiate the job
     ErasureCodeJob encodeJob = new ErasureCodeJob(jobdesc, this.async, user,
-            settings.getHadoopDir());
+            settings.getHadoopDir(), hdfsLeDescriptorsFacade.getSingleEndpoint());
     //persist a job execution instance in the database and get its id
     Execution exec = encodeJob.requestExecutionId();
     System.out.println("\nSTarting the erasure coding job\n");

--- a/src/main/java/se/kth/hopsworks/rest/ElasticHit.java
+++ b/src/main/java/se/kth/hopsworks/rest/ElasticHit.java
@@ -6,11 +6,13 @@ import java.util.Map.Entry;
 import java.util.logging.Logger;
 import javax.xml.bind.annotation.XmlRootElement;
 import org.elasticsearch.search.SearchHit;
-import static se.kth.hopsworks.rest.Index.CHILD;
 import static se.kth.hopsworks.rest.Index.DATASET;
-import static se.kth.hopsworks.rest.Index.PARENT;
+import static se.kth.hopsworks.rest.Index.DS;
+import static se.kth.hopsworks.rest.Index.INODE;
+import static se.kth.hopsworks.rest.Index.PROJ;
 import static se.kth.hopsworks.rest.Index.PROJECT;
 import static se.kth.hopsworks.rest.Index.UNKNOWN;
+import static se.kth.hopsworks.rest.Index.SITE;
 
 /**
  * Represents a JSONifiable version of the elastic hit object
@@ -47,19 +49,19 @@ public class ElasticHit {
     Index index = Index.valueOf(hit.getIndex().toUpperCase());
     switch (index) {
       case PROJECT:
-        if (hit.getType().equalsIgnoreCase(PARENT.toString())) {
+        if (hit.getType().equalsIgnoreCase(SITE.toString())) {
           this.type = PROJECT.toString().toLowerCase();
-        } else if (hit.getType().equalsIgnoreCase(CHILD.toString())) {
-          this.type = CHILD.toString().toLowerCase();
+        } else if (hit.getType().equalsIgnoreCase(PROJ.toString())) {
+          this.type = PROJ.toString().toLowerCase();
         } else {
           this.type = UNKNOWN.toString().toLowerCase();
         }
         break;
       case DATASET:
-        if (hit.getType().equalsIgnoreCase(PARENT.toString())) {
-          this.type = DATASET.toString().toLowerCase();
-        } else if (hit.getType().equalsIgnoreCase(CHILD.toString())) {
-          this.type = CHILD.toString().toLowerCase();
+        if (hit.getType().equalsIgnoreCase(DS.toString())) {
+          this.type = DS.toString().toLowerCase();
+        } else if (hit.getType().equalsIgnoreCase(INODE.toString())) {
+          this.type = INODE.toString().toLowerCase();
         } else {
           this.type = UNKNOWN.toString().toLowerCase();
         }

--- a/src/main/java/se/kth/hopsworks/rest/Index.java
+++ b/src/main/java/se/kth/hopsworks/rest/Index.java
@@ -8,12 +8,10 @@ package se.kth.hopsworks.rest;
 public enum Index {
   
   PROJECT,
-  //
   DATASET,
-  //
-  PARENT,
-  //
-  CHILD,
-  //
+  SITE,
+  PROJ,
+  DS,
+  INODE,
   UNKNOWN
 }

--- a/src/main/java/se/kth/hopsworks/util/Settings.java
+++ b/src/main/java/se/kth/hopsworks/util/Settings.java
@@ -408,10 +408,10 @@ public class Settings {
   public static final String META_DATA_FIELD = "EXTENDED_METADATA";
   public static final String META_PROJECT_INDEX = "project";
   public static final String META_DATASET_INDEX = "dataset";
-  public static final String META_PROJECT_PARENT_TYPE = "parent";
-  public static final String META_PROJECT_CHILD_TYPE = "child";
-  public static final String META_DATASET_PARENT_TYPE = "parent";
-  public static final String META_DATASET_CHILD_TYPE = "child";
+  public static final String META_PROJECT_PARENT_TYPE = "site";
+  public static final String META_PROJECT_CHILD_TYPE = "proj";
+  public static final String META_DATASET_PARENT_TYPE = "ds";
+  public static final String META_DATASET_CHILD_TYPE = "inode";
   public static final String META_INODE_SEARCHABLE_FIELD = "searchable";
   public static final String META_INODE_OPERATION_FIELD = "operation";
 

--- a/src/main/java/se/kth/hopsworks/zeppelin/socket/ZeppelinEndpointConfig.java
+++ b/src/main/java/se/kth/hopsworks/zeppelin/socket/ZeppelinEndpointConfig.java
@@ -35,7 +35,7 @@ public class ZeppelinEndpointConfig extends ServerEndpointConfig.Configurator {
     config.getUserProperties().put("httpSession", httpSession);
     config.getUserProperties().put("user", request.getUserPrincipal().getName());
     config.getUserProperties().put("projectID", cookies.get("projectID"));
-    logger.log(Level.INFO, "Connecting to zeppelin: User={0} Project id={1}",
+    logger.log(Level.FINE, "Connecting to zeppelin: User={0} Project id={1}",
             new Object[]{cookies.get("email"), cookies.get("projectID")});
   }
 

--- a/src/main/webapp/security/protected/admin/mobileUsers.xhtml
+++ b/src/main/webapp/security/protected/admin/mobileUsers.xhtml
@@ -99,9 +99,9 @@
 
             </h:form>
 
-            <script>
+<!--            <script>
                     userMgmtTabview.select(#{roleEnforcementPoint.tabIndex});
-            </script>
+            </script>-->
           </div>
         </div> 
       </p:layoutUnit>

--- a/yo/app/index.html
+++ b/yo/app/index.html
@@ -50,7 +50,7 @@
 
     <!-- build:js(.) scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="bower_components/jquery/dist/jquery.js"></script>
+    <script src="bower_components/jquery/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
     <script src="bower_components/angular-animate/angular-animate.js"></script>

--- a/yo/app/views/datasets.html
+++ b/yo/app/views/datasets.html
@@ -477,7 +477,7 @@
                       </div>
 
                     </md-tab>
-                    <md-tab label="Activity">
+<!--                    <md-tab label="Activity">
                       <md-content class="md-padding" style="padding-left: 20px;padding-right: 20px;">
 
                         <div class="row">
@@ -544,7 +544,7 @@
                           </md-whiteframe>
                         </div>
                       </md-content>
-                    </md-tab>
+                    </md-tab>-->
                   </md-tabs>
                 </md-content>
               </div>

--- a/yo/app/views/datasetsBrowser.html
+++ b/yo/app/views/datasetsBrowser.html
@@ -110,8 +110,9 @@
                                 <i ng-click="datasetsCtrl.openDir(file)"
                                    ng-show="!file.dir" class="glyphicon glyphicon-file" style="padding-right: 5px; color: #757575;float: left;margin-top: 4px;"></i>
                                 <div ng-click="datasetsCtrl.openDir(file)">{{file.name}}</div></td>
-                              <td ng-click="datasetsCtrl.openDir(file)">{{file.owner}} <span style=" color: #757575; font-size: 12px; padding-left: 5px;">
-                                {{file.email}}</span></td>
+                              <td ng-click="datasetsCtrl.openDir(file)">{{file.owner}} 
+<!--                                <span style=" color: #757575; font-size: 12px; padding-left: 5px;">{{file.email}}</span>-->
+                              </td>
                               <td ng-click="datasetsCtrl.openDir(file)">{{file.modification| date:'short'}} <span style=" color: #757575; font-size: 12px; padding-left: 5px;">me</span>
                               </td>
                               <td ng-click="datasetsCtrl.openDir(file)" style="width: 12%;">{{(file.size == 0? '_': projectCtrl.sizeOnDisk(file.size))}}</td>
@@ -162,13 +163,13 @@
                                   </ul>
                                 </div>
                               </td>
-
+                              
                               <td style="margin:0px;width:25px;">
-                                  <i ng-if="$index >= 5 && (!file.underConstruction && !datasetsCtrl.working)"
+<!--                                  <i ng-if="$index >= 5 && (!file.underConstruction && !datasetsCtrl.working)"
                                      title="This file is compressed"
                                      style="color: lightgrey; margin-top:3px;"
                                      class="glyphicon glyphicon-compressed">
-                                  </i>
+                                  </i>-->
                                   <i ng-if="file.underConstruction && !datasetsCtrl.working"
                                      title="File under construction"
                                      style="color: lightgrey; margin-top:3px;"
@@ -403,7 +404,7 @@
                               </div>
 
                             </md-tab>
-                            <md-tab label="Activity">
+<!--                            <md-tab label="Activity">
                               <md-content class="md-padding" style="padding-left: 20px;padding-right: 20px;">
 
                                 <div class="row">
@@ -470,7 +471,7 @@
                                   </md-whiteframe>
                                 </div>
                               </md-content>
-                            </md-tab>
+                            </md-tab>-->
                           </md-tabs>
                         </md-content>
                       </div>

--- a/yo/test/karma.conf.js
+++ b/yo/test/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
     // list of files / patterns to load in the browser
     files: [
       // bower:js
-      'bower_components/jquery/dist/jquery.js',
+      'bower_components/jquery/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/bootstrap/dist/js/bootstrap.js',
       'bower_components/angular-animate/angular-animate.js',


### PR DESCRIPTION
Support for elastic 2.x by renaming parent and child attributes for indexes 'project' and 'dataset'. We now have project index parent 'site' and child 'proj'. Dataset index has parent 'ds' and child 'inode.
For yarn jobs, we now pass in the ip:port of the first namenode found in the leader election table. 
Increase allowed password length from 13 to 255.