### PR TITLE
Keep certificates in HDFS until the job completes

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnJob.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnJob.java
@@ -11,6 +11,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -339,6 +340,10 @@ public abstract class YarnJob extends HopsJob {
    * }
    * }
    */
+  
+  final EnumSet<YarnApplicationState> finalAppState = EnumSet.of(
+      YarnApplicationState.FINISHED, YarnApplicationState.FAILED,
+      YarnApplicationState.KILLED);
   /**
    * Monitor the state of the job.
    * <p/>
@@ -403,7 +408,7 @@ public abstract class YarnJob extends HopsJob {
                   + getExecution() + ". Tried " + failures + " time(s).", ex);
         }
         //Remove local and hdfs files (localresources)this job uses
-        if (!removedFiles && appState == YarnApplicationState.RUNNING) {
+        if (!removedFiles && finalAppState.contains(appState)) {
           try {
             runner.removeAllNecessary();
             removedFiles = true;
@@ -425,6 +430,7 @@ public abstract class YarnJob extends HopsJob {
           updateFinalStatus(JobFinalStatus.KILLED);
           updateProgress(0);
           finalState = JobState.KILLED;
+          runner.removeAllNecessary();
         } catch (YarnException | IOException ex) {
           LOG.log(Level.SEVERE,
                   "Failed to cancel execution, " + getExecution()


### PR DESCRIPTION
Until now, the certificates (keystore and truststore) were kept in HDFS until the job reached the state of RUNNING. This is problematic though since an application might be running but a container might fail for whatever reason and rescheduled. NodeManager should be able to localize the LocalResources of the container otherwise it will never be launched. In addition, Spark supports dynamic executors which can be launched any time during the application life-cycle.

With that PR, the material is deleted from HDFS only when the application has reached a final state, FINISHED, FAILED or KILLED, or when it has failed more than our threshold.