### PR TITLE
Jupyter webproxy fix ( https://hopshadoop.atlassian.net/browse/HOPSWORKS-89 )

### DIFF
--- a/hopsworks-api/pom.xml
+++ b/hopsworks-api/pom.xml
@@ -17,6 +17,12 @@
   <name>hopsworks-api</name>
     
   <dependencies>
+
+<dependency>
+  <groupId>com.fasterxml.jackson.jaxrs</groupId>
+  <artifactId>jackson-jaxrs-json-provider</artifactId>
+  <version>2.2.3</version>
+</dependency>
     
     <dependency>
       <groupId>io.hops</groupId>

--- a/hopsworks-api/pom.xml
+++ b/hopsworks-api/pom.xml
@@ -17,12 +17,6 @@
   <name>hopsworks-api</name>
     
   <dependencies>
-
-<dependency>
-  <groupId>com.fasterxml.jackson.jaxrs</groupId>
-  <artifactId>jackson-jaxrs-json-provider</artifactId>
-  <version>2.2.3</version>
-</dependency>
     
     <dependency>
       <groupId>io.hops</groupId>

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsRouter.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsRouter.java
@@ -40,8 +40,6 @@ public class HopsRouter extends Router {
   public HopsRouter(URI targetUri) throws Exception {
     this.exchangeStore = new LimitedMemoryExchangeStore();
     transport = createTransport(targetUri);
-//    ProxyConfiguration proxyConfiguration=null;
-//    resolverMap.getHTTPSchemaResolver().getHttpClientConfig().setProxy(proxyConfiguration);
   }
 
   /**

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsServletHandler.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsServletHandler.java
@@ -37,6 +37,7 @@ import com.predic8.membrane.core.transport.http.AbortException;
 import com.predic8.membrane.core.transport.http.AbstractHttpHandler;
 import com.predic8.membrane.core.transport.http.EOFWhileReadingFirstLineException;
 import com.predic8.membrane.core.util.EndOfStreamException;
+import io.hops.hopsworks.common.util.Ip;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
@@ -82,17 +83,18 @@ class HopsServletHandler extends AbstractHttpHandler {
 //        DNSCache dnsCache = getTransport().getRouter().getDnsCache();
 //        String ip = dnsCache.getHostAddress(remoteAddr);
 //        exchange.setRemoteAddrIp("127.0.0.1");
-        exchange.setRemoteAddrIp(this.request.getRemoteAddr());
-        exchange.setRemoteAddr(this.request.getRemoteHost());
+//        exchange.setRemoteAddrIp(this.request.getRemoteAddr());
+        exchange.setRemoteAddrIp(Ip.getHost(request.getRequestURL().toString()));
+        exchange.setRemoteAddr(Ip.getHost(request.getRequestURL().toString()));
+//        exchange.setRemoteAddr(this.request.getRemoteHost());
 //        exchange.setRemoteAddr(this.targetHost.getHostName());
-        
-        
+
 //        exchange.setRemoteAddr(this.targetUriObj.toString());
 //        exchange.setRemoteAddr(getTransport().isReverseDNS() ? dnsCache.
 //                getHostName(remoteAddr) : ip);
-
         exchange.setRequest(srcReq);
-        exchange.setOriginalRequestUri(srcReq.getUri());
+//        exchange.setOriginalRequestUri(srcReq.getUri());
+        exchange.setOriginalRequestUri(request.getRequestURL().toString());
 
         invokeHandlers();
       } catch (AbortException e) {
@@ -194,8 +196,11 @@ class HopsServletHandler extends AbstractHttpHandler {
   @Override
   public InetAddress getLocalAddress() {
     try {
-      //    return localAddr;
-      return InetAddress.getLocalHost();
+//      return InetAddress.getLocalHost();
+//      return InetAddress.getByName(request.getLocalAddr());
+
+      String externalIp = Ip.getHost(request.getRequestURL().toString());
+      return InetAddress.getByName(externalIp);
     } catch (UnknownHostException ex) {
       Logger.getLogger(HopsServletHandler.class.getName()).
               log(Level.SEVERE, null, ex);

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsServletHandler.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsServletHandler.java
@@ -81,8 +81,12 @@ class HopsServletHandler extends AbstractHttpHandler {
       try {
 //        DNSCache dnsCache = getTransport().getRouter().getDnsCache();
 //        String ip = dnsCache.getHostAddress(remoteAddr);
-        exchange.setRemoteAddrIp("127.0.0.1");
-        exchange.setRemoteAddr(this.targetHost.getHostName());
+//        exchange.setRemoteAddrIp("127.0.0.1");
+        exchange.setRemoteAddrIp(this.request.getRemoteAddr());
+        exchange.setRemoteAddr(this.request.getRemoteHost());
+//        exchange.setRemoteAddr(this.targetHost.getHostName());
+        
+        
 //        exchange.setRemoteAddr(this.targetUriObj.toString());
 //        exchange.setRemoteAddr(getTransport().isReverseDNS() ? dnsCache.
 //                getHostName(remoteAddr) : ip);

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsServletHandler.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/HopsServletHandler.java
@@ -54,7 +54,6 @@ class HopsServletHandler extends AbstractHttpHandler {
 
   private final HttpServletRequest request;
   private final HttpServletResponse response;
-//  private URI srcUriObj = null;
   private URI targetUriObj = null;
   private HttpHost targetHost = null;
 
@@ -64,7 +63,6 @@ class HopsServletHandler extends AbstractHttpHandler {
     super(transport);
     this.request = request;
     this.response = response;
-//    this.srcUriObj = srcUri;
     this.targetUriObj = targetUriObj;
     this.targetHost = URIUtils.extractHost(targetUriObj);
 
@@ -80,20 +78,9 @@ class HopsServletHandler extends AbstractHttpHandler {
       exchange.received();
 
       try {
-//        DNSCache dnsCache = getTransport().getRouter().getDnsCache();
-//        String ip = dnsCache.getHostAddress(remoteAddr);
-//        exchange.setRemoteAddrIp("127.0.0.1");
-//        exchange.setRemoteAddrIp(this.request.getRemoteAddr());
         exchange.setRemoteAddrIp(Ip.getHost(request.getRequestURL().toString()));
         exchange.setRemoteAddr(Ip.getHost(request.getRequestURL().toString()));
-//        exchange.setRemoteAddr(this.request.getRemoteHost());
-//        exchange.setRemoteAddr(this.targetHost.getHostName());
-
-//        exchange.setRemoteAddr(this.targetUriObj.toString());
-//        exchange.setRemoteAddr(getTransport().isReverseDNS() ? dnsCache.
-//                getHostName(remoteAddr) : ip);
         exchange.setRequest(srcReq);
-//        exchange.setOriginalRequestUri(srcReq.getUri());
         exchange.setOriginalRequestUri(request.getRequestURL().toString());
 
         invokeHandlers();
@@ -148,7 +135,6 @@ class HopsServletHandler extends AbstractHttpHandler {
     if (request.getQueryString() != null) {
       pathQuery += "?" + request.getQueryString();
     }
-//    String pathQuery = this.targetUriObj.toString();
 
     if (getTransport().isRemoveContextRoot()) {
       String contextPath = request.getContextPath();
@@ -196,9 +182,6 @@ class HopsServletHandler extends AbstractHttpHandler {
   @Override
   public InetAddress getLocalAddress() {
     try {
-//      return InetAddress.getLocalHost();
-//      return InetAddress.getByName(request.getLocalAddr());
-
       String externalIp = Ip.getHost(request.getRequestURL().toString());
       return InetAddress.getByName(externalIp);
     } catch (UnknownHostException ex) {
@@ -211,7 +194,6 @@ class HopsServletHandler extends AbstractHttpHandler {
   @Override
   public int getLocalPort() {
     return request.getLocalPort();
-//    return -1;
   }
 
   @Override

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -33,14 +33,12 @@ import com.predic8.membrane.core.rules.ProxyRuleKey;
 import com.predic8.membrane.core.rules.ServiceProxy;
 import com.predic8.membrane.core.rules.ServiceProxyKey;
 import io.hops.hopsworks.common.util.Ip;
-import io.hops.hopsworks.common.util.Settings;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.ejb.EJB;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
@@ -53,8 +51,8 @@ public class MembraneServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
   private static final Log logger = LogFactory.getLog(MembraneServlet.class);
 
-  @EJB
-  private Settings settings;
+//  @EJB
+//  private Settings settings;
 
   @Override
   public void init(ServletConfig config) throws ServletException {
@@ -71,10 +69,6 @@ public class MembraneServlet extends HttpServlet {
             getQueryString();
 
     Router router;
-//    int hash = queryString.indexOf('#');
-//    if (hash >= 0) {
-//      queryString = queryString.substring(0, hash);
-//    }
 
 // For websockets, the following paths are used by JupyterHub:
 //  /(user/[^/]*)/(api/kernels/[^/]+/channels|terminals/websocket)/?
@@ -100,23 +94,13 @@ public class MembraneServlet extends HttpServlet {
 
     String externalIp = Ip.getHost(req.getRequestURL().toString());
 
-//    StringBuffer urlBuf = new StringBuffer("http://127.0.0.1:");//note: StringBuilder isn't supported by Matcher
     StringBuffer urlBuf
             = new StringBuffer("http://"
-//                    + externalIp
-                    //                    + settings.getHopsworksExternalIp()
                                         + "localhost"
                     + ":"
-//                                + settings.getHopsworksPort()
             );
 
     String ctxPath = req.getRequestURI();
-
-//    boolean websocket = false;
-//    if (ctxPath.contains("/api/kernels/")) {
-//      urlBuf = new StringBuffer("ws://127.0.0.1:");
-//      websocket = true;
-//    }
 
     int x = ctxPath.indexOf("/jupyter");
     int firstSlash = ctxPath.indexOf('/', x + 1);
@@ -144,18 +128,12 @@ public class MembraneServlet extends HttpServlet {
       throw new ServletException("Rewritten targetUri is invalid: "
               + newTargetUri, e);
     }
-    // settings.getHopsworksIp()
     ServiceProxy sp = new ServiceProxy(
             new ServiceProxyKey(
-                    //                        req.getRemoteAddr(), "*", "*", -1),
                     externalIp, "*", "*", -1),
             "localhost", targetPort);
-//            new ServiceProxyKey("localhost", "*", "*", -1), "localhost",
-//            new ServiceProxyKey("*", "*", "*", -1), "localhost", targetPort);
-//    sp.setTargetURL(newQueryBuf.toString());
     sp.setTargetURL(newQueryBuf.toString());
     // only set external hostname in case admin console is used
-//    sp.setExternalHostname(externalIp);
     try {
       router = new HopsRouter(targetUriObj);
       router.add(sp);

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -132,13 +132,15 @@ public class MembraneServlet extends HttpServlet {
       throw new ServletException("Rewritten targetUri is invalid: "
               + newTargetUri, e);
     }
-    ServiceProxy sp = new ServiceProxy(
-            new ServiceProxyKey(settings.
-            getHopsworksIp(), "*", "*", -1), "localhost", targetPort);
+    ServiceProxy sp = new ServiceProxy(new ServiceProxyKey(
+            settings.getHopsworksIp(), "*", "*", -1),
+            settings.getHopsworksIp(), targetPort);
 // new ServiceProxyKey("localhost", "*", "*", -1), "localhost", targetPort);
     sp.setTargetURL(newQueryBuf.toString());
     try {
       router = new HopsRouter(targetUriObj);
+      router.add(sp);
+      router.init();
       ProxyRule proxy = new ProxyRule(new ProxyRuleKey(-1));
       router.getRuleManager().addProxy(proxy,
               RuleManager.RuleDefinitionSource.MANUAL);

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -32,6 +32,7 @@ import com.predic8.membrane.core.rules.ProxyRule;
 import com.predic8.membrane.core.rules.ProxyRuleKey;
 import com.predic8.membrane.core.rules.ServiceProxy;
 import com.predic8.membrane.core.rules.ServiceProxyKey;
+import io.hops.hopsworks.common.util.Ip;
 import io.hops.hopsworks.common.util.Settings;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -97,10 +98,21 @@ public class MembraneServlet extends HttpServlet {
       params.put(pair.getName(), pair.getValue());
     }
 
-    StringBuffer urlBuf = new StringBuffer("http://127.0.0.1:");//note: StringBuilder isn't supported by Matcher
+    String externalIp = Ip.getHost(req.getRequestURL().toString());
+
+//    StringBuffer urlBuf = new StringBuffer("http://127.0.0.1:");//note: StringBuilder isn't supported by Matcher
+    StringBuffer urlBuf
+            = new StringBuffer("http://"
+//                    + externalIp
+                    //                    + settings.getHopsworksExternalIp()
+                                        + "localhost"
+                    + ":"
+//                                + settings.getHopsworksPort()
+            );
+
     String ctxPath = req.getRequestURI();
 
-    boolean websocket = false;
+//    boolean websocket = false;
 //    if (ctxPath.contains("/api/kernels/")) {
 //      urlBuf = new StringBuffer("ws://127.0.0.1:");
 //      websocket = true;
@@ -132,11 +144,18 @@ public class MembraneServlet extends HttpServlet {
       throw new ServletException("Rewritten targetUri is invalid: "
               + newTargetUri, e);
     }
-    ServiceProxy sp = new ServiceProxy(new ServiceProxyKey(
-            settings.getHopsworksIp(), "*", "*", -1),
+    // settings.getHopsworksIp()
+    ServiceProxy sp = new ServiceProxy(
+            new ServiceProxyKey(
+                    //                        req.getRemoteAddr(), "*", "*", -1),
+                    externalIp, "*", "*", -1),
             "localhost", targetPort);
-// new ServiceProxyKey("localhost", "*", "*", -1), "localhost", targetPort);
+//            new ServiceProxyKey("localhost", "*", "*", -1), "localhost",
+//            new ServiceProxyKey("*", "*", "*", -1), "localhost", targetPort);
+//    sp.setTargetURL(newQueryBuf.toString());
     sp.setTargetURL(newQueryBuf.toString());
+    // only set external hostname in case admin console is used
+//    sp.setExternalHostname(externalIp);
     try {
       router = new HopsRouter(targetUriObj);
       router.add(sp);

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -54,8 +54,7 @@ public class MembraneServlet extends HttpServlet {
 
   @EJB
   private Settings settings;
-  
-  
+
   @Override
   public void init(ServletConfig config) throws ServletException {
   }
@@ -76,23 +75,15 @@ public class MembraneServlet extends HttpServlet {
 //      queryString = queryString.substring(0, hash);
 //    }
 
-
 // For websockets, the following paths are used by JupyterHub:
 //  /(user/[^/]*)/(api/kernels/[^/]+/channels|terminals/websocket)/?
 // forward to ws(s)://servername:port_number
-
 //<LocationMatch "/mypath/(user/[^/]*)/(api/kernels/[^/]+/channels|terminals/websocket)(.*)">
 //    ProxyPassMatch ws://localhost:8999/mypath/$1/$2$3
 //    ProxyPassReverse ws://localhost:8999 # this may be superfluous
 //</LocationMatch>
-
-
-
 //        ProxyPass /api/kernels/ ws://192.168.254.23:8888/api/kernels/
 //        ProxyPassReverse /api/kernels/ http://192.168.254.23:8888/api/kernels/
-
-
-
     List<NameValuePair> pairs;
     try {
       //note: HttpClient 4.2 lets you parse the string without building the URI
@@ -108,15 +99,13 @@ public class MembraneServlet extends HttpServlet {
 
     StringBuffer urlBuf = new StringBuffer("http://127.0.0.1:");//note: StringBuilder isn't supported by Matcher
     String ctxPath = req.getRequestURI();
-    
+
     boolean websocket = false;
 //    if (ctxPath.contains("/api/kernels/")) {
 //      urlBuf = new StringBuffer("ws://127.0.0.1:");
 //      websocket = true;
 //    }
-    
-    
-    
+
     int x = ctxPath.indexOf("/jupyter");
     int firstSlash = ctxPath.indexOf('/', x + 1);
     int secondSlash = ctxPath.indexOf('/', firstSlash + 1);
@@ -144,7 +133,9 @@ public class MembraneServlet extends HttpServlet {
               + newTargetUri, e);
     }
     ServiceProxy sp = new ServiceProxy(
-            new ServiceProxyKey("localhost", "*", "*", -1), "localhost", targetPort);
+            new ServiceProxyKey("localhost", "*", "*", -1), settings.
+            getHopsworksIp(), targetPort);
+// new ServiceProxyKey("localhost", "*", "*", -1), "localhost", targetPort);
     sp.setTargetURL(newQueryBuf.toString());
     try {
       router = new HopsRouter(targetUriObj);

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -133,8 +133,8 @@ public class MembraneServlet extends HttpServlet {
               + newTargetUri, e);
     }
     ServiceProxy sp = new ServiceProxy(
-            new ServiceProxyKey("localhost", "*", "*", -1), settings.
-            getHopsworksIp(), targetPort);
+            new ServiceProxyKey(settings.
+            getHopsworksIp(), "*", "*", -1), "localhost", targetPort);
 // new ServiceProxyKey("localhost", "*", "*", -1), "localhost", targetPort);
     sp.setTargetURL(newQueryBuf.toString());
     try {

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -134,7 +134,7 @@ public class MembraneServlet extends HttpServlet {
     }
     ServiceProxy sp = new ServiceProxy(new ServiceProxyKey(
             settings.getHopsworksIp(), "*", "*", -1),
-            settings.getHopsworksIp(), targetPort);
+            "localhost", targetPort);
 // new ServiceProxyKey("localhost", "*", "*", -1), "localhost", targetPort);
     sp.setTargetURL(newQueryBuf.toString());
     try {

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/agent/AgentResource.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/agent/AgentResource.java
@@ -382,6 +382,7 @@ public class AgentResource {
       for (CondaCommands cc : allCommands) {
         if (cc.getStatus() != PythonDepsFacade.CondaStatus.FAILED) {
           commandsToExec.add(cc);
+          cc.setHostId(host);
         }
       }
       commands.addAll(commandsToExec);
@@ -392,8 +393,10 @@ public class AgentResource {
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
 
-    GenericEntity<List<CondaCommands>> commandsForKagent
-            = new GenericEntity<List<CondaCommands>>(commands) {    };
+
+
+    GenericEntity<Collection<CondaCommands>> commandsForKagent
+            = new GenericEntity<Collection<CondaCommands>>(commands) {    };
 
     return noCacheResponse.getNoCacheResponseBuilder(Response.Status.OK).entity(
             commandsForKagent).build();

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterFacade.java
@@ -151,7 +151,8 @@ public class JupyterFacade {
     // delete JupyterProject entity bean
   }
 
-  public JupyterProject saveServer(Project project, String secret, int port,
+  public JupyterProject saveServer(String host,
+          Project project, String secret, int port,
           int hdfsUserId,
           String token, long pid, int driverCores, String driverMemory,
           int numExecutors, int executorCores, String executorMemory, int gpus,
@@ -160,8 +161,7 @@ public class JupyterFacade {
     JupyterProject jp = null;
     String ip;
 //    ip = settings.getHopsworksIp() + ":" + settings.getHopsworksPort();
-    ip = "localhost:" + settings.getHopsworksPort();
-//              InetAddress.getLocalHost().getHostAddress();
+    ip = host + ":" + settings.getHopsworksPort();
 
     jp = new JupyterProject(project, secret, port, hdfsUserId, ip, token, pid,
             driverCores, driverMemory, numExecutors, executorCores,
@@ -178,7 +178,7 @@ public class JupyterFacade {
     }
   }
 
-  private void update(JupyterProject jp) {
+  public void update(JupyterProject jp) {
     if (jp != null) {
       em.merge(jp);
     }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/AsyncSystemCommandExecutor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/AsyncSystemCommandExecutor.java
@@ -1,0 +1,82 @@
+package io.hops.hopsworks.common.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public class AsyncSystemCommandExecutor {
+
+  private List<String> commandInformation;
+  private String adminPassword;
+  private ThreadedStreams inputStreamHandler;
+  private ThreadedStreams errorStreamHandler;
+
+  private static final Logger logger = LoggerFactory
+          .getLogger(AsyncSystemCommandExecutor.class);
+
+  public AsyncSystemCommandExecutor(final List<String> commandInformation) {
+    if (commandInformation == null) {
+      throw new NullPointerException("The commandInformation is required.");
+    }
+    this.commandInformation = commandInformation;
+    this.adminPassword = null;
+  }
+
+  public int executeCommand()
+          throws IOException, InterruptedException {
+    int exitValue = -99;
+
+    try {
+      ProcessBuilder pb = new ProcessBuilder(commandInformation);
+      Process process = pb.start();
+
+      // you need this if you're going to write something to the command's input stream
+      // (such as when invoking the 'sudo' command, and it prompts you for a password).
+      OutputStream stdOutput = process.getOutputStream();
+
+      // i'm currently doing these on a separate line here in case i need to set them to null
+      // to get the threads to stop.
+      // see http://java.sun.com/j2se/1.5.0/docs/guide/misc/threadPrimitiveDeprecation.html
+      InputStream inputStream = process.getInputStream();
+      InputStream errorStream = process.getErrorStream();
+
+      // these need to run as java threads to get the standard output and error from the command.
+      // the inputstream handler gets a reference to our stdOutput in case we need to write
+      // something to it, such as with the sudo command
+      inputStreamHandler = new ThreadedStreams(inputStream, stdOutput,
+              adminPassword);
+      errorStreamHandler = new ThreadedStreams(errorStream);
+
+      // TODO the inputStreamHandler has a nasty side-effect of hanging if the given password is wrong; fix it
+      inputStreamHandler.start();
+      errorStreamHandler.start();
+
+      // TODO a better way to do this?
+//      exitValue = process.waitFor();
+
+    } catch (IOException e) {
+      // TODO deal with this here, or just throw it?
+      throw e;
+    }
+    return exitValue;
+  }
+
+  /**
+   * Get the standard output (stdout) from the command you just exec'd.
+   */
+  public String getStandardOutputFromCommand() {
+    return inputStreamHandler.getOutputBuffer();
+  }
+
+  /**
+   * Get the standard error (stderr) from the command you just exec'd.
+   */
+  public String getStandardErrorFromCommand() {
+    return errorStreamHandler.getOutputBuffer();
+  }
+
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Ip.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Ip.java
@@ -29,4 +29,25 @@ public class Ip {
     }
   }
 
+  public static String getHost(String url) {
+    if (url == null || url.length() == 0) {
+      return "";
+    }
+
+    int doubleslash = url.indexOf("//");
+    if (doubleslash == -1) {
+      doubleslash = 0;
+    } else {
+      doubleslash += 2;
+    }
+
+    int end = url.indexOf('/', doubleslash);
+    end = end >= 0 ? end : url.length();
+
+    int port = url.indexOf(':', doubleslash);
+    end = (port > 0 && port < end) ? port : end;
+
+    return url.substring(doubleslash, end);
+  }
+
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/LocalhostServices.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/LocalhostServices.java
@@ -118,7 +118,7 @@ public class LocalhostServices {
     // TODO: Hopswork-chef needs to put script in glassfish directory!
     List<String> commands = new ArrayList<>();
     commands.add("/usr/bin/sudo");
-    commands.add(intermediateCaDir + "/" + Settings.SSL_CREATE_CERT_SCRIPTNAME );
+    commands.add(intermediateCaDir + "/" + Settings.SSL_CREATE_CERT_SCRIPTNAME);
     commands.add(service);
     commands.add(countryCode);
     commands.add(city);
@@ -208,6 +208,32 @@ public class LocalhostServices {
     }
 
     return projectName + Settings.HOPS_USERNAME_SEPARATOR + username;
+  }
+
+  public static String unzipHdfsFile(String hdfsFile, String localFolder,
+          String domainsDir) throws IOException {
+
+    List<String> commands = new ArrayList<>();
+    commands.add(domainsDir + "/bin/" + Settings.UNZIP_FILES_SCRIPTNAME);
+    commands.add(hdfsFile);
+    commands.add(localFolder);
+
+    AsyncSystemCommandExecutor commandExecutor = new AsyncSystemCommandExecutor(
+            commands);
+    String stdout = "", stderr = "";
+    try {
+      int result = commandExecutor.executeCommand();
+      // get the stdout and stderr from the command that was run
+      stdout = commandExecutor.getStandardOutputFromCommand();
+      stderr = commandExecutor.getStandardErrorFromCommand();
+      if (result != 0) {
+        throw new IOException(stderr);
+      }
+    } catch (InterruptedException e) {
+      throw new IOException("Interrupted. Could not generate the certificates: "
+              + stderr);
+    }
+    return stdout;
   }
 
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -1089,6 +1089,7 @@ public class Settings implements Serializable {
   private static final String INTERMEDIATE_CA_DIR = CA_DIR + "/intermediate";
   public static final String SSL_CREATE_CERT_SCRIPTNAME = "createusercerts.sh";
   public static final String SSL_DELETE_CERT_SCRIPTNAME = "deleteusercerts.sh";
+  public static final String UNZIP_FILES_SCRIPTNAME = "unzip-hdfs-files.sh";
   public static final String SSL_DELETE_PROJECT_CERTS_SCRIPTNAME
           = "deleteprojectcerts.sh";
   public static final int USERNAME_LEN = 8;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -443,6 +443,18 @@ public class Settings implements Serializable {
     return HADOOP_DIR;
   }
 
+  
+  private String HOPSWORKS_EXTERNAL_IP = "127.0.0.1";
+
+  public synchronized String getHopsworksExternalIp() {
+    checkCache();
+    return HOPSWORKS_EXTERNAL_IP;
+  }
+  
+  public synchronized void setHopsworksExternalIp(String ip) {
+    HOPSWORKS_EXTERNAL_IP = ip;
+  }
+  
   private String HOPSWORKS_IP = "127.0.0.1";
 
   public synchronized String getHopsworksIp() {


### PR DESCRIPTION
It only worked for localhost before.
Now it works for remote hosts (hope it still works for localhost :)) 

There was another bug with Jackson dependencies being pull in from ServiceProxy. Now they are 'provided' scope and Payara provides them.

https://hopshadoop.atlassian.net/browse/HOPSWORKS-89