### PR TITLE
HOPSWORKS-168 Set environment variables for TFoS submitted in Job UI

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -261,6 +261,41 @@ public class SparkYarnRunnerBuilder {
     builder.addToAppMasterEnvironment("SPARK_YARN_MODE", "true");
     builder.addToAppMasterEnvironment("SPARK_YARN_STAGING_DIR", stagingPath);
     builder.addToAppMasterEnvironment("SPARK_USER", jobUser);
+
+    //Set TensorFlowOnSpark required environment variables
+    if (jobType == JobType.TFSPARK) {
+
+      //Should always be false in case of TFoS
+      dynamicExecutors = false;
+
+      //No point in retrying since clusterspec is static
+      addSystemProperty(Settings.SPARK_MAX_APP_ATTEMPTS, "1");
+
+      //This is needed to solve a bug where the driver is able to allocate GPUs
+      builder.addToAppMasterEnvironment("CUDA_VISIBLE_DEVICES", "''");
+
+      //The following configuration is based on:
+      //https://github.com/yahoo/TensorFlowOnSpark/wiki/GetStarted_YARN
+
+      //IMPORTANT, if TFoS still can't find cuda libraries there may be issues with cuda installation
+      // 1. ssh to machine where the container failed
+      // 2. Make sure /usr/local/cuda exists and is a symlink pointing to e.g. /usr/local/cuda-8.0
+      // 3. Make sure /etc/ld.so.conf.d directory on the host has an entry pointing to /usr/local/cuda/lib64
+      // 4. Run 'sudo ldconfig'
+
+      String binCuda = "/usr/local/cuda/bin";
+      String libCuda = "/usr/local/cuda/lib64";
+      String libJVM = settings.getJavaHome() + "/jre/lib/amd64/server";
+      String libHDFS = settings.getHadoopDir() + "/lib/native";
+
+      builder.addToAppMasterEnvironment("PATH", binCuda + ":$PATH");
+      builder.addToAppMasterEnvironment("LD_LIBRARY_PATH", libCuda);
+
+      addSystemProperty(Settings.SPARK_EXECUTORENV_PATH, binCuda + ":$PATH");
+      addSystemProperty(Settings.SPARK_EXECUTORENV_LD_LIBRARY_PATH,
+              libCuda + ":" + libJVM + ":" + libHDFS);
+    }
+
     for (String key : envVars.keySet()) {
       builder.addToAppMasterEnvironment(key, envVars.get(key));
     }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -283,8 +283,8 @@ public class SparkYarnRunnerBuilder {
       // 3. Make sure /etc/ld.so.conf.d directory on the host has an entry pointing to /usr/local/cuda/lib64
       // 4. Run 'sudo ldconfig'
 
-      String binCuda = "/usr/local/cuda/bin";
-      String libCuda = "/usr/local/cuda/lib64";
+      String binCuda = settings.getCudaDir() + "/bin";
+      String libCuda = settings.getCudaDir() + "/lib64";
       String libJVM = settings.getJavaHome() + "/jre/lib/amd64/server";
       String libHDFS = settings.getHadoopDir() + "/lib/native";
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -392,6 +392,7 @@ public class Settings implements Serializable {
           = "spark.yarn.stagingDir";
   public static final String SPARK_JAVA_LIBRARY_PROP = "java.library.path";
   public static final String SPARK_METRICS_ENV = "spark.metrics.conf";
+  public static final String SPARK_MAX_APP_ATTEMPTS = "spark.yarn.maxAppAttempts";
   //PySpark properties
   public static final String SPARK_APP_NAME_ENV = "spark.app.name";
   public static final String SPARK_EXECUTORENV_PYTHONPATH
@@ -400,6 +401,8 @@ public class Settings implements Serializable {
           = "spark.executorEnv.LD_LIBRARY_PATH";
   public static final String SPARK_YARN_IS_PYTHON_ENV = "spark.yarn.isPython";
   public static final String SPARK_PYTHONPATH = "PYTHONPATH";
+  public static final String SPARK_EXECUTORENV_PATH
+          = "spark.executorEnv.PATH";
   public static final String SPARK_PYSPARK_PYTHON = "PYSPARK_PYTHON";
   //TFSPARK properties
   public static final String SPARK_TF_GPUS_ENV = "spark.executor.gpus";


### PR DESCRIPTION
[HOPSWORKS-168] This PR sets the environment variables for TFoS executors launched in Job UI.