### PR TITLE
[HOPSWORKS-127] 

### DIFF
--- a/hopsworks-common/pom.xml
+++ b/hopsworks-common/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.hops</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.7.3</version>
+      <version>2.8.2</version>
       <exclusions>
         <exclusion>
           <groupId>com.sun.jersey</groupId>

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnMonitor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnMonitor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.apache.hadoop.yarn.api.records.LogAggregationStatus;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.exceptions.YarnException;
@@ -49,6 +50,10 @@ public final class YarnMonitor implements Closeable {
     return yarnClient.getApplicationReport(appId).getYarnApplicationState();
   }
 
+  public LogAggregationStatus getLogAggregationStatus() throws YarnException, IOException {
+    return yarnClient.getApplicationReport(appId).getLogAggregationStatus();
+  }
+  
   public FinalApplicationStatus getFinalApplicationStatus() throws YarnException,
           IOException {
     return yarnClient.getApplicationReport(appId).getFinalApplicationStatus();


### PR DESCRIPTION
check that the log aggregation is finished for the jobs killed during the project removal, before to remove the users from HDFS.
This reduce the risk of having users being put back in HDFS by the log aggregation process after the project removal. It would be better to check for all the applications belonging to the project users, but the resource manager does not recover the log aggregation status, this result in the impossibility to know if we should wait for log aggregation or not for job that run before a resource manager restart.

Need Hop 2.8.2