### PR TITLE
HOPSWORKS-227 Spark executor should not export CUDA_VISIBLE_DEVICES

### DIFF
--- a/hopsworks-common/src/main/resources/io/hops/jupyter/config_template.json
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/config_template.json
@@ -71,7 +71,6 @@
             "spark.executorEnv.PYSPARK_PYTHON" : "%%pyspark_bin%%",
             "spark.executorEnv.PYSPARK3_PYTHON" : "%%pyspark_bin%%",
             "spark.executorEnv.LD_LIBRARY_PATH" : "%%java_home%%/jre/lib/amd64/server:%%cuda_dir%%/lib64:%%hadoop_home%%/lib/native",
-            "spark.executorEnv.CUDA_VISIBLE_DEVICES" : "",
             "spark.pyspark.python" : "%%pyspark_bin%%",
             "spark.shuffle.service.enabled" : "true",
             "spark.submit.deployMode" : "cluster",


### PR DESCRIPTION
HOPSWORKS-227 Spark executor should not export CUDA_VISIBLE_DEVICES