### PR TITLE
HOPSWORKS-193 Fix GPU utilization bar

### DIFF
--- a/hopsworks-web/yo/app/scripts/controllers/clusterUtilisationCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/clusterUtilisationCtrl.js
@@ -50,7 +50,7 @@ angular.module('hopsWorksApp')
                         } else {
                           self.gpuBarClass = 'progress-bar-danger';
                         }
-                        self.gpusPercent = (self.allocatedGPUs/totalGpus);
+                        self.gpusPercent = (self.allocatedGPUs/totalGpus)*100;
 
                       }, function (error) {
                         console.log("Problem getting GPU utilization");


### PR DESCRIPTION
The current GPU utilization calculation is off by a factor of 100