### PR TITLE
[HOPSWORKS-263]

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfig.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfig.java
@@ -319,8 +319,9 @@ public class JupyterConfig {
                   "files", js.getFiles(),
                   "pyFiles", "\"" + js.getPyFiles() + "\"",
                   "yarn_queue", "default",
-                  "num_ps", Integer.toString(js.getNumTfPs()),
-                  "num_gpus", Integer.toString(js.getNumTfGpus()),
+                  "num_ps", (js.getMode().compareToIgnoreCase("distributedtensorflow") == 0)
+                              ? Integer.toString(js.getNumTfPs()) : "0",
+                  "num_gpus", (isTensorflow) ? Integer.toString(js.getNumTfGpus()) : "0",
                   "tensorflow", Boolean.toString(isTensorflow),
                   "jupyter_home", this.confDirPath,
                   "project", this.project.getName(),


### PR DESCRIPTION
[HOPSWORKS-263] Write defensive code to ensure TensorFlow specific parameters are never set for a non-TensorFlow job.