### PR TITLE
HOPSWORKS-290

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/server/ZeppelinConfig.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/server/ZeppelinConfig.java
@@ -496,6 +496,18 @@ public class ZeppelinConfig {
         .append(this.projectName).append(File.separator)
         .append(this.projectName).append("__tstore.jks#")
         .append(Settings.T_CERTIFICATE);
+  
+    // If RPC TLS is enabled, password file would be injected by the
+    // NodeManagers. We don't need to add it as LocalResource
+    if (!settings.getHopsRpcTls()) {
+      sparkDistFiles
+          // File with crypto material password
+          .append(",")
+          .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+          .append(this.projectName).append(File.separator)
+          .append(this.projectName).append("__cert.key#")
+          .append(Settings.CRYPTO_MATERIAL_PASSWORD);
+    }
 
     StringBuilder keyStoreSB = new StringBuilder();
     keyStoreSB
@@ -507,7 +519,7 @@ public class ZeppelinConfig {
         .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
         .append(this.projectName).append(File.separator).append(this.projectName)
         .append("__tstore.jks#").append(Settings.T_CERTIFICATE);
-        
+    
     // Comma-separated files to be added as local resources to Livy interpreter
     StringBuilder livySparkDistFiles = new StringBuilder();
     livySparkDistFiles
@@ -515,6 +527,19 @@ public class ZeppelinConfig {
         .append(keyStoreSB).append(",")
         // TrustStore
         .append(trustStoreSB);
+    
+    // If RPC TLS is enabled, password file would be injected by the
+    // NodeManagers. We don't need to add it as LocalResource
+    if (!settings.getHopsRpcTls()) {
+      StringBuilder materialPasswd = new StringBuilder();
+      materialPasswd
+          // File with crypto material password
+          .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+          .append(this.projectName).append(File.separator).append(this.projectName)
+          .append("__cert.key#").append(Settings.CRYPTO_MATERIAL_PASSWORD);
+      
+      livySparkDistFiles.append(",").append(materialPasswd);
+    }
 
     if (interpreterConf == null) {
       StringBuilder interpreter_json = ConfigFileGenerator.

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfig.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfig.java
@@ -294,7 +294,19 @@ public class JupyterConfig {
           .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
           .append("__tstore.jks#").append(Settings.T_CERTIFICATE).append("\",")
           .append("\""+Settings.getSparkLog4JPath(settings.getSparkUser()) + "\"");
-
+      
+      // If RPC TLS is enabled, password file would be injected by the
+      // NodeManagers. We don't need to add it as LocalResource
+      if (!settings.getHopsRpcTls()) {
+        sparkFiles
+            .append(",")
+            // File with crypto material password
+            .append("\"hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+            .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
+            .append("__cert.key#").append(Settings.CRYPTO_MATERIAL_PASSWORD)
+            .append("\"");
+      }
+      
       if(!js.getFiles().equals("")) {
         sparkFiles.append("," + js.getFiles());
       }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/kafka/KafkaFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/kafka/KafkaFacade.java
@@ -930,7 +930,7 @@ public class KafkaFacade {
     try {
       HopsUtils.copyUserKafkaCerts(userCerts, project, user.getUsername(),
               settings.getHopsworksTmpCertDir(), null,
-          certificateMaterializer);
+          certificateMaterializer, settings.getHopsRpcTls());
   
       String projectSpecificUser = hdfsUsersController.getHdfsUserName(project,
           user);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/exception/CryptoPasswordNotFoundException.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/exception/CryptoPasswordNotFoundException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.hopsworks.common.exception;
+
+public class CryptoPasswordNotFoundException extends Exception {
+  public CryptoPasswordNotFoundException(String message) {
+    super(message);
+  }
+
+  public CryptoPasswordNotFoundException(Throwable cause) {
+    super(cause);
+  }
+  
+  public CryptoPasswordNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFsService.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFsService.java
@@ -20,6 +20,7 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 
+import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
 import io.hops.hopsworks.common.util.BaseHadoopClientsService;
 import io.hops.hopsworks.common.util.Settings;
 import org.apache.hadoop.conf.Configuration;
@@ -187,12 +188,9 @@ public class DistributedFsService {
             newConf);
   
         return new DistributedFileSystemOps(ugi, newConf);
-      } catch (BaseHadoopClientsService.CryptoPasswordNotFoundException ex) {
+      } catch (CryptoPasswordNotFoundException ex) {
         logger.log(Level.SEVERE, ex.getMessage(), ex);
-        String[] project_username = username.split(HdfsUsersController
-            .USER_NAME_DELIMITER);
-        bhcs.removeNonSuperUserCertificate(project_username[1],
-            project_username[0]);
+        bhcs.removeNonSuperUserCertificate(username);
         return null;
       }
     }
@@ -202,10 +200,8 @@ public class DistributedFsService {
 
   public void closeDfsClient(DistributedFileSystemOps udfso) {
     if (null != udfso) {
-      String[] tokens = udfso.getEffectiveUser().split(HdfsUsersController
-          .USER_NAME_DELIMITER);
-      if (null != tokens && tokens.length == 2 && settings.getHopsRpcTls()) {
-        bhcs.removeNonSuperUserCertificate(tokens[1], tokens[0]);
+      if (settings.getHopsRpcTls()) {
+        bhcs.removeNonSuperUserCertificate(udfso.getEffectiveUser());
       }
       udfso.close();
     }
@@ -245,12 +241,9 @@ public class DistributedFsService {
             newConf);
     
         return new DistributedFileSystemOps(ugi, newConf);
-      } catch (BaseHadoopClientsService.CryptoPasswordNotFoundException ex) {
+      } catch (CryptoPasswordNotFoundException ex) {
         logger.log(Level.SEVERE, ex.getMessage(), ex);
-        String[] project_username = username.split(HdfsUsersController
-            .USER_NAME_DELIMITER);
-        bhcs.removeNonSuperUserCertificate(project_username[1],
-            project_username[0]);
+        bhcs.removeNonSuperUserCertificate(username);
         return null;
       }
     }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/flink/AbstractYarnClusterDescriptor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/flink/AbstractYarnClusterDescriptor.java
@@ -530,7 +530,7 @@ public abstract class AbstractYarnClusterDescriptor implements
         null, null, jobSystemProperties,
         services.getSettings().getFlinkKafkaCertDir(),
         appResponse.getApplicationId().toString(),
-        services.getCertificateMaterializer());
+        services.getCertificateMaterializer(), services.getSettings().getHopsRpcTls());
   
     StringBuilder tmpBuilder = new StringBuilder();
     for (Map.Entry<String, String> prop : jobSystemProperties.entrySet()) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -2,6 +2,7 @@ package io.hops.hopsworks.common.jobs.spark;
 
 import com.google.common.base.Strings;
 import io.hops.hopsworks.common.dao.jobs.description.Jobs;
+import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
 import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
 import io.hops.hopsworks.common.jobs.AsynchronousJobExecutor;
 import io.hops.hopsworks.common.jobs.jobhistory.JobType;
@@ -122,13 +123,16 @@ public class SparkYarnRunnerBuilder {
     builder.setYarnClient(yarnClient);
     builder.setDfsClient(dfsClient);
     builder.setJobUser(jobUser);
-    try {
-      String password = services.getBaseHadoopClientsService()
-          .getProjectSpecificUserCertPassword(jobUser);
-      builder.setKeyStorePassword(password);
-      builder.setTrustStorePassword(password);
-    } catch (Exception ex) {
-      throw new IOException(ex);
+    if (settings.getHopsRpcTls()) {
+      try {
+        String password = services.getBaseHadoopClientsService()
+            .getProjectSpecificUserCertPassword(jobUser);
+        builder.setKeyStorePassword(password);
+        builder.setTrustStorePassword(password);
+      } catch (CryptoPasswordNotFoundException ex) {
+        LOG.log(Level.SEVERE, ex.getMessage(), ex);
+        throw new IOException(ex);
+      }
     }
 
     String stagingPath = "/Projects/" + project + "/"
@@ -244,8 +248,9 @@ public class SparkYarnRunnerBuilder {
 
     //Add extra files to local resources, use filename as key
     for (LocalResourceDTO dto : extraFiles) {
-      if (dto.getName().equals(Settings.K_CERTIFICATE) || dto.getName().equals(
-          Settings.T_CERTIFICATE)) {
+      if (dto.getName().equals(Settings.K_CERTIFICATE)
+          || dto.getName().equals(Settings.T_CERTIFICATE)
+          || dto.getName().equals(Settings.CRYPTO_MATERIAL_PASSWORD)) {
         //Set deletion to true so that certs are removed
         builder.addLocalResource(dto, true);
       } else {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/tensorflow/TensorFlowYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/tensorflow/TensorFlowYarnRunnerBuilder.java
@@ -69,7 +69,9 @@ public class TensorFlowYarnRunnerBuilder {
 
     //Add extra files to local resources, use filename as key
     for (LocalResourceDTO dto : extraFiles) {
-      if (!dto.getName().equals(Settings.K_CERTIFICATE) && !dto.getName().equals(Settings.T_CERTIFICATE)) {
+      if (!dto.getName().equals(Settings.K_CERTIFICATE)
+          && !dto.getName().equals(Settings.T_CERTIFICATE)
+          && !dto.getName().equals(Settings.CRYPTO_MATERIAL_PASSWORD)) {
         String pathToResource = dto.getPath();
         pathToResource = pathToResource.replaceFirst("hdfs:/*Projects",
             "hdfs:///Projects");

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnRunner.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnRunner.java
@@ -162,7 +162,8 @@ public class YarnRunner {
         services.getSettings().getHopsworksTmpCertDir(),
         services.getSettings().getHdfsTmpCertDir(), jobType,
         dfso, materialResources, systemProperties,
-        applicationId, services.getCertificateMaterializer());
+        applicationId, services.getCertificateMaterializer(),
+        services.getSettings().getHopsRpcTls());
 
     for (LocalResourceDTO materialDTO : materialResources) {
       amLocalResourcesOnHDFS.put(materialDTO.getName(), materialDTO);
@@ -249,8 +250,10 @@ public class YarnRunner {
       }
 
       // Set keystore and truststore passwords
-      appContext.setKeyStorePassword(keyStorePassword);
-      appContext.setTrustStorePassword(trustStorePassword);
+      if (services.getSettings().getHopsRpcTls()) {
+        appContext.setKeyStorePassword(keyStorePassword);
+        appContext.setTrustStorePassword(trustStorePassword);
+      }
       
       //And submit
       logger.log(Level.INFO,
@@ -352,14 +355,34 @@ public class YarnRunner {
         
         tfClient.addFile(kstore);
         tfClient.addFile(tstore);
+        
         tfClient.getFilesInfo().put(kstore, new LocalResourceInfo(Settings
             .K_CERTIFICATE, kstore, LocalResourceVisibility.PRIVATE.toString(),
             LocalResourceType.FILE.toString(), null));
         tfClient.getFilesInfo().put(tstore, new LocalResourceInfo(Settings
             .T_CERTIFICATE, tstore, LocalResourceVisibility.PRIVATE.toString(),
             LocalResourceType.FILE.toString(), null));
+  
+        // If RPC TLS is enabled, password file would be injected by the
+        // NodeManagers. We don't need to add it as LocalResource
+        if (!services.getSettings().getHopsRpcTls()) {
+          String passFile =
+              "hdfs://" + services.getSettings().getHdfsTmpCertDir()
+                  + File.separator + project.getName() + HdfsUsersController
+                  .USER_NAME_DELIMITER + username + File.separator +
+                  appId.toString()
+                  + File.separator + HopsUtils.getProjectMaterialPasswordName(
+                  project.getName(), username);
+          tfClient.addFile(passFile);
+          tfClient.getFilesInfo().put(passFile, new LocalResourceInfo(Settings
+              .CRYPTO_MATERIAL_PASSWORD, passFile, LocalResourceVisibility.PRIVATE
+              .toString(), LocalResourceType.FILE.toString(), null));
+          logger.log(Level.INFO, "Adding local resource {0}", passFile);
+        }
+        
         logger.log(Level.INFO, "Adding local resource {0}", kstore);
         logger.log(Level.INFO, "Adding local resource {0}", tstore);
+        
         
         tfClient.submitApplication(app);
 //        String logstashInfo = tfClient.getEnvironment().get(Settings.LOGSTASH_JOB_INFO);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/user/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/user/CertificateMaterializer.java
@@ -20,7 +20,13 @@ package io.hops.hopsworks.common.user;
 import io.hops.hopsworks.common.dao.certificates.CertsFacade;
 import io.hops.hopsworks.common.dao.certificates.ServiceCerts;
 import io.hops.hopsworks.common.dao.certificates.UserCerts;
+import io.hops.hopsworks.common.dao.project.Project;
+import io.hops.hopsworks.common.dao.project.ProjectFacade;
+import io.hops.hopsworks.common.dao.user.UserFacade;
+import io.hops.hopsworks.common.dao.user.Users;
+import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
+import io.hops.hopsworks.common.util.HopsUtils;
 import io.hops.hopsworks.common.util.Settings;
 import org.apache.commons.io.FileUtils;
 
@@ -69,6 +75,12 @@ public class CertificateMaterializer {
   private CertsFacade certsFacade;
   @EJB
   private Settings settings;
+  @EJB
+  private UserFacade userFacade;
+  @EJB
+  private ProjectFacade projectFacade;
+  @EJB
+  private HdfsUsersController hdfsUsersController;
   @Resource
   private ManagedScheduledExecutorService scheduler;
   
@@ -82,7 +94,9 @@ public class CertificateMaterializer {
     TIME_SUFFIXES.put("d", TimeUnit.DAYS);
   }
   
-  private final Map<MaterialKey, CryptoMaterial> materialMap =
+  private final String CERT_PASS_SUFFIX = "__cert.key";
+  
+  private final Map<MaterialKey, InternalCryptoMaterial> materialMap =
       new ConcurrentHashMap<>();
   private final Map<Integer, Set<String>> openInterpreterGroupsPerProject =
       new ConcurrentHashMap<>();
@@ -193,7 +207,7 @@ public class CertificateMaterializer {
   public void materializeCertificates(String username, String projectName)
     throws IOException {
     MaterialKey key = new MaterialKey(username, projectName);
-    CryptoMaterial material = materialMap.get(key);
+    InternalCryptoMaterial material = materialMap.get(key);
     FileRemover scheduledRemover = null;
     LOG.log(Level.FINEST, "Requested materialization for: " + key
         .getProjectSpecificUsername());
@@ -238,6 +252,7 @@ public class CertificateMaterializer {
   }
   
   private void materialize(MaterialKey key) throws IOException {
+    String decryptedPass;
     // Spark interpreter in Zeppelin runs as user PROJECTNAME and not as
     // PROJECTNAME__USERNAME
     if (key.isSparkInterpreter()) {
@@ -248,22 +263,64 @@ public class CertificateMaterializer {
             .getProjectSpecificUsername());
       }
       ServiceCerts storedMaterial = serviceCerts.get(0);
+      decryptedPass = decryptMaterialPassword(key
+          .getProjectSpecificUsername(), storedMaterial
+          .getCertificatePassword(), ServiceCerts.class);
       materializeInternal(key, storedMaterial.getServiceKey(),
-          storedMaterial.getServiceCert());
+          storedMaterial.getServiceCert(), decryptedPass);
     } else {
       UserCerts projectSpecificCerts = certsFacade.findUserCert(key.projectName,
           key.username);
-    
+      decryptedPass = decryptMaterialPassword(key
+          .getProjectSpecificUsername(), projectSpecificCerts.getUserKeyPwd(),
+          UserCerts.class);
       materializeInternal(key, projectSpecificCerts.getUserKey(),
-          projectSpecificCerts.getUserCert());
+          projectSpecificCerts.getUserCert(), decryptedPass);
+    }
+  }
+  
+  private <T> String decryptMaterialPassword(String certificateIdentifier,
+      String encryptedPassword, Class<T> cls) throws IOException {
+    String userPassword;
+    if (cls == ServiceCerts.class) {
+      // Project generic certificate
+      // Certificate identifier would be the project name
+      Project project = projectFacade.findByName(certificateIdentifier);
+      if (project == null) {
+        throw new IOException("Project with name " + certificateIdentifier +
+            " could not be found");
+      }
+      Users owner = project.getOwner();
+      userPassword = owner.getPassword();
+    } else if (cls == UserCerts.class) {
+      // Project specific certificate
+      // Certificate identifier would be the project specific username
+      String username = hdfsUsersController.getUserName(certificateIdentifier);
+      Users user = userFacade.findByUsername(username);
+      if (user == null) {
+        throw new IOException("Could not find user: " + username);
+      }
+      userPassword = user.getPassword();
+    } else {
+      throw new IllegalArgumentException("Certificate type " + cls.getName()
+          + " is unknown");
+    }
+    
+    try {
+      return HopsUtils.decrypt(userPassword, settings
+          .getHopsworksMasterPasswordSsl(), encryptedPassword);
+    } catch (Exception ex) {
+      throw new IOException(ex);
     }
   }
   
   private void materializeInternal(MaterialKey key, byte[] keyStore, byte[]
-      trustStore) throws IOException {
+      trustStore, String password) throws IOException {
     if (null != keyStore && null != trustStore) {
-      flushToLocalFs(key.getProjectSpecificUsername(), keyStore, trustStore);
-      materialMap.put(key, new CryptoMaterial(keyStore, trustStore));
+      flushToLocalFs(key.getProjectSpecificUsername(), keyStore, trustStore,
+          password);
+      materialMap.put(key, new InternalCryptoMaterial(keyStore, trustStore,
+          password));
       LOG.log(Level.FINEST, "User: " + key.getProjectSpecificUsername() + " " +
           "Material DOES NOT exist, flushing now!!!");
     } else {
@@ -273,18 +330,24 @@ public class CertificateMaterializer {
     }
   }
   
-  public byte[][] getUserMaterial(String projectName) {
+  public CryptoMaterial getUserMaterial(String projectName)
+    throws CryptoPasswordNotFoundException {
     return getUserMaterial(null, projectName);
   }
   
   @Lock(LockType.READ)
-  public byte[][] getUserMaterial(String username, String projectName) {
+  public CryptoMaterial getUserMaterial(String username, String projectName)
+    throws CryptoPasswordNotFoundException {
     MaterialKey key = new MaterialKey(username, projectName);
-    CryptoMaterial material = materialMap.get(key);
+    InternalCryptoMaterial material = materialMap.get(key);
     if (null != material) {
-      return new byte[][]{material.getKeyStore(), material.getTrustStore()};
+      return new CryptoMaterial(material.getKeyStore(), material
+          .getTrustStore(), material.getPassword());
     }
-    return null;
+    
+    throw new CryptoPasswordNotFoundException(
+        "Cryptographic material for user " + key.getProjectSpecificUsername() +
+            " does not exist!");
   }
   
   public void removeCertificate(String projectName) {
@@ -295,7 +358,7 @@ public class CertificateMaterializer {
   @AccessTimeout(value=100)
   public void removeCertificate(String username, String projectName) {
     MaterialKey key = new MaterialKey(username, projectName);
-    CryptoMaterial material = materialMap.get(key);
+    InternalCryptoMaterial material = materialMap.get(key);
     if (null != material) {
       LOG.log(Level.FINEST, "Requested removal of material for " + key
           .getProjectSpecificUsername() + " Ref: " + material.references);
@@ -398,25 +461,33 @@ public class CertificateMaterializer {
         + "__kstore.jks").toFile();
     File tstoreFile = Paths.get(transientDir, username
         + "__tstore.jks").toFile();
+    File certPassFile = Paths.get(transientDir, username
+        + CERT_PASS_SUFFIX).toFile();
     FileUtils.deleteQuietly(kstoreFile);
     FileUtils.deleteQuietly(tstoreFile);
+    FileUtils.deleteQuietly(certPassFile);
   }
   
-  private void flushToLocalFs(String username, byte[] kstore, byte[] tstore)
-      throws IOException {
-    File kstoreFile = Paths.get(transientDir, username + "__kstore.jks").toFile();
-    File tstoreFile = Paths.get(transientDir, username + "__tstore.jks").toFile();
+  private void flushToLocalFs(String username, byte[] kstore, byte[] tstore,
+      String password) throws IOException {
+    File kstoreFile = Paths.get(transientDir, username + "__kstore.jks")
+        .toFile();
+    File tstoreFile = Paths.get(transientDir, username + "__tstore.jks")
+        .toFile();
+    File certPassFile = Paths.get(transientDir, username + CERT_PASS_SUFFIX)
+        .toFile();
   
     FileUtils.writeByteArrayToFile(kstoreFile, kstore, false);
     FileUtils.writeByteArrayToFile(tstoreFile, tstore, false);
+    FileUtils.writeStringToFile(certPassFile, password, false);
   }
   
   private class FileRemover implements Runnable {
     private final MaterialKey key;
-    private final CryptoMaterial material;
+    private final InternalCryptoMaterial material;
     private ScheduledFuture scheduledFuture;
     
-    private FileRemover(MaterialKey key, CryptoMaterial material) {
+    private FileRemover(MaterialKey key, InternalCryptoMaterial material) {
       this.key = key;
       this.material = material;
     }
@@ -483,23 +554,37 @@ public class CertificateMaterializer {
     }
   }
   
-  private class CryptoMaterial {
-    private int references;
+  public class CryptoMaterial {
     private final byte[] keyStore;
     private final byte[] trustStore;
+    private final String password;
     
-    private CryptoMaterial(byte[] keystore, byte[] trustStore) {
-      this.keyStore = keystore;
+    public CryptoMaterial(byte[] keyStore, byte[] trustStore, String password) {
+      this.keyStore = keyStore;
       this.trustStore = trustStore;
-      references = 1;
+      this.password = password;
     }
     
-    private byte[] getKeyStore() {
+    public byte[] getKeyStore() {
       return keyStore;
     }
     
-    private byte[] getTrustStore() {
+    public byte[] getTrustStore() {
       return trustStore;
+    }
+    
+    public String getPassword() {
+      return password;
+    }
+  }
+  
+  private class InternalCryptoMaterial extends CryptoMaterial {
+    private int references;
+    
+    private InternalCryptoMaterial(byte[] keystore, byte[] trustStore,
+        String password) {
+      super(keystore, trustStore, password);
+      references = 1;
     }
     
     private boolean decrementReference() {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/BaseHadoopClientsService.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/BaseHadoopClientsService.java
@@ -18,14 +18,15 @@
 package io.hops.hopsworks.common.util;
 
 import io.hops.hopsworks.common.dao.certificates.CertsFacade;
-import io.hops.hopsworks.common.dao.certificates.UserCerts;
+import io.hops.hopsworks.common.dao.project.ProjectFacade;
 import io.hops.hopsworks.common.dao.user.UserFacade;
-import io.hops.hopsworks.common.dao.user.Users;
+import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
 import io.hops.hopsworks.common.user.CertificateMaterializer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.net.HopsSSLSocketFactory;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory;
 import org.apache.hadoop.security.ssl.SSLFactory;
 
@@ -46,6 +47,8 @@ public class BaseHadoopClientsService {
   @EJB
   private UserFacade userFacade;
   @EJB
+  private ProjectFacade projectFacade;
+  @EJB
   private CertsFacade certsFacade;
   @EJB
   protected Settings settings;
@@ -55,6 +58,7 @@ public class BaseHadoopClientsService {
   private String superKeystorePassword;
   private String superTrustStorePath;
   private String superTrustStorePassword;
+  private String superuser;
   
   private final Logger LOG = Logger.getLogger(
       BaseHadoopClientsService.class.getName());
@@ -90,6 +94,11 @@ public class BaseHadoopClientsService {
     superTrustStorePassword = sslConf.get(
         FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER,
             FileBasedKeyStoresFactory.SSL_TRUSTSTORE_PASSWORD_TPL_KEY));
+    try {
+      superuser = UserGroupInformation.getLoginUser().getUserName();
+    } catch (IOException ex) {
+      throw new IllegalStateException("Could not identify login user");
+    }
   }
   
   public String getSuperKeystorePath() {
@@ -109,27 +118,29 @@ public class BaseHadoopClientsService {
   }
   
   public String getProjectSpecificUserCertPassword(String username)
-    throws Exception {
-    String[] project_username = username.split(HdfsUsersController
-        .USER_NAME_DELIMITER);
-    Users user = userFacade.findByUsername(project_username[1]);
-    UserCerts userCert = certsFacade.findUserCert(project_username[0],
-        project_username[1]);
-    String encryptedPass = userCert.getUserKeyPwd();
-    return HopsUtils.decrypt(user.getPassword(), settings
-        .getHopsworksMasterPasswordSsl(), encryptedPass);
+    throws CryptoPasswordNotFoundException {
+    CertificateMaterializer.CryptoMaterial cryptoMaterial;
+    if (username.matches(HopsSSLSocketFactory.USERNAME_PATTERN)) {
+      String[] project_username = username.split(HdfsUsersController
+          .USER_NAME_DELIMITER);
+  
+      cryptoMaterial = certificateMaterializer
+          .getUserMaterial(project_username[1], project_username[0]);
+      return cryptoMaterial.getPassword();
+    } else if (!username.equals(superuser)){
+      // It's project wide user
+      cryptoMaterial = certificateMaterializer.getUserMaterial(username);
+      return cryptoMaterial.getPassword();
+    } else {
+      throw new IllegalArgumentException("User " + username + " is not a " +
+          "project specific username nor a project wide");
+    }
   }
   
   public void configureTlsForProjectSpecificUser(String username, String
       transientDir, Configuration conf) throws CryptoPasswordNotFoundException {
-    String password;
-    try {
-      password = getProjectSpecificUserCertPassword(username);
-    } catch (Exception ex) {
-      throw new CryptoPasswordNotFoundException(
-          "Could not find crypto material in database for user " + username,
-          ex);
-    }
+    String password = getProjectSpecificUserCertPassword(username);
+    
     String prefix = Paths.get(transientDir, username).toString();
     String kstorePath = prefix + HopsSSLSocketFactory.KEYSTORE_SUFFIX;
     String tstorePath = prefix + HopsSSLSocketFactory.TRUSTSTORE_SUFFIX;
@@ -140,7 +151,8 @@ public class BaseHadoopClientsService {
   public void materializeCertsForNonSuperUser(String username) {
     // Make sure it's a normal, non superuser
     if (username.matches(HopsSSLSocketFactory.USERNAME_PATTERN)) {
-      String[] tokens = username.split(HdfsUsersController.USER_NAME_DELIMITER);
+      String[] tokens = username.split(HdfsUsersController
+          .USER_NAME_DELIMITER, 2);
       if (tokens.length == 2) {
         try {
           certificateMaterializer.materializeCertificates(tokens[1], tokens[0]);
@@ -149,28 +161,27 @@ public class BaseHadoopClientsService {
               "user certificates " + ex.getMessage(), ex);
         }
       }
+    } else if (!username.equals(superuser)){
+      try {
+        certificateMaterializer.materializeCertificates(username);
+      } catch (IOException ex) {
+        throw new RuntimeException("Error while materializing " +
+            "user certificates " + ex.getMessage(), ex);
+      }
     }
   }
   
-  public void removeNonSuperUserCertificate(String username, String
-      projectName) {
-    if (null != username && !username.equals(settings.getHdfsSuperUser())
-        && null != projectName) {
-      certificateMaterializer.removeCertificate(username, projectName);
-    }
-  }
-  
-  public class CryptoPasswordNotFoundException extends Exception {
-    public CryptoPasswordNotFoundException(String message) {
-      super(message);
-    }
-  
-    public CryptoPasswordNotFoundException(Throwable cause) {
-      super(cause);
-    }
-    
-    public CryptoPasswordNotFoundException(String message, Throwable cause) {
-      super(message, cause);
+  public void removeNonSuperUserCertificate(String username) {
+    if (username != null
+        && username.matches(HopsSSLSocketFactory.USERNAME_PATTERN)) {
+      String[] tokens = username.split(HdfsUsersController
+          .USER_NAME_DELIMITER, 2);
+      if (tokens.length == 2) {
+        certificateMaterializer.removeCertificate(tokens[1], tokens[0]);
+      }
+    } else if (username != null
+        && !username.matches(superuser)) {
+      certificateMaterializer.removeCertificate(username);
     }
   }
   

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -1346,6 +1346,7 @@ public class Settings implements Serializable {
   public static final String KAFKA_DEFAULT_CONSUMER_GROUP = "default";
   public static final String K_CERTIFICATE = "k_certificate";
   public static final String T_CERTIFICATE = "t_certificate";
+  public static final String CRYPTO_MATERIAL_PASSWORD = "material_passwd";
 
   //Used to retrieve schema by HopsUtil
   public static final String HOPSWORKS_PROJECTID_PROPERTY

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/yarn/YarnClientService.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/yarn/YarnClientService.java
@@ -1,5 +1,6 @@
 package io.hops.hopsworks.common.yarn;
 
+import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
 import io.hops.hopsworks.common.util.BaseHadoopClientsService;
 import io.hops.hopsworks.common.util.Settings;
@@ -85,12 +86,11 @@ public class YarnClientService {
             newConf);
   
         return createYarnClient(username, newConf);
-      } catch (BaseHadoopClientsService.CryptoPasswordNotFoundException ex) {
+      } catch (CryptoPasswordNotFoundException ex) {
         LOG.log(Level.SEVERE, ex.getMessage(), ex);
         String[] project_username = username.split(HdfsUsersController
             .USER_NAME_DELIMITER);
-        bhcs.removeNonSuperUserCertificate(project_username[1],
-            project_username[0]);
+        bhcs.removeNonSuperUserCertificate(username);
         return null;
       }
     }
@@ -135,7 +135,9 @@ public class YarnClientService {
           String username = yarnClientWrapper.getUsername();
           String projectName = yarnClientWrapper.getProjectName();
           if (null != username && null != projectName) {
-            bhcs.removeNonSuperUserCertificate(username, projectName);
+            String projectSpecificUser = projectName + HdfsUsersController
+                .USER_NAME_DELIMITER + username;
+            bhcs.removeNonSuperUserCertificate(projectSpecificUser);
           }
         }
       }


### PR DESCRIPTION
* Write crypto material password to a file in transient dir

* Fix bug with project generic user trying to access hdfs

* Add crypto material file as local resource for jobs launched from job ui. Small fix for YarnClientService regarding users

* Get crypto material password from CertificateMaterializer instead of going to DB again

* Add file with certificates password as LocalResource only when RPC TLS is disabled, otherwise it is injected by the NodeManager

* Fix bug with crypto material password when RPC TLS is disabled

* Materialize certificates passwd file for Zeppelin and Jupyter

* Add double quotes for Jupyter conf

* Change CertificateMaterializer#getUserMaterial to throw an exception instead of returning null in case of missing crypto material for a user

https://hopshadoop.atlassian.net/browse/HOPSWORKS-290