### PR TITLE
HOPSWORKS-329

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/NotebookRestApi.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/NotebookRestApi.java
@@ -1055,6 +1055,13 @@ public class NotebookRestApi {
         noteName = "Note " + note.getId();
       }
       note.setName(noteName);
+      Set<String> owners = notebook.getNotebookAuthorization().getOwners(note
+          .getId());
+      String projectGenericUser = hdfsUsersController.getProjectName(hdfsUserName)
+          + Settings.PROJECT_GENERIC_USER_SUFFIX;
+      owners.add(projectGenericUser);
+      notebook.getNotebookAuthorization().setOwners(note.getId(), owners);
+      
       note.persist(subject);
       noteInfo = new NoteInfo(note);
       zeppelinResource.persistToDB(this.project);

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServer.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServer.java
@@ -353,7 +353,11 @@ public class NotebookServer {
           break;
       }
     } catch (Exception e) {
-      LOG.log(Level.SEVERE, "Can't handle message", e);
+      Level logLevel = Level.SEVERE;
+      if (e.getMessage().contains("is not allowed to empty the Trash")) {
+        logLevel = Level.INFO;
+      }
+      LOG.log(logLevel, "Can't handle message", e);
     }
   }
 

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServerImplFactory.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServerImplFactory.java
@@ -14,6 +14,8 @@ import javax.ejb.EJB;
 import javax.ejb.Singleton;
 import javax.websocket.Session;
 
+import io.hops.hopsworks.common.dao.project.team.ProjectTeamFacade;
+import io.hops.hopsworks.common.dao.user.activity.ActivityFacade;
 import io.hops.hopsworks.common.util.Settings;
 import org.sonatype.aether.RepositoryException;
 
@@ -29,6 +31,10 @@ public class NotebookServerImplFactory {
   private Settings settings;
   @EJB
   private CertsFacade certsFacade;
+  @EJB
+  private ProjectTeamFacade projectTeamFacade;
+  @EJB
+  private ActivityFacade activityFacade;
   
   private Map<String, NotebookServerImpl> notebookServerImpls = new HashMap<>();
 
@@ -45,7 +51,8 @@ public class NotebookServerImplFactory {
     }
     NotebookServerImpl impl = notebookServerImpls.get(projectName);
     if (impl == null) {
-      impl = new NotebookServerImpl(project, zeppelinConfigFactory, certsFacade, settings);
+      impl = new NotebookServerImpl(project, zeppelinConfigFactory, certsFacade,
+          settings, projectTeamFacade, activityFacade);
       notebookServerImpls.put(projectName, impl);
     }
     impl.addConnectedSocket(session);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/user/activity/ActivityFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/user/activity/ActivityFacade.java
@@ -43,6 +43,7 @@ public class ActivityFacade extends AbstractFacade<Activity> {
   public static final String DELETED_JOB = " deleted a job named ";
   public static final String SCHEDULED_JOB = " scheduled a job named ";
   public static final String EXECUTED_JOB = " ran a job used as input file ";
+  public static final String TRASH_NOTEBOOK = " moved to Zeppelin Trash ";
   // Flag constants
   public static final String FLAG_PROJECT = "PROJECT";
   public static final String FLAG_DATASET = "DATASET";

--- a/hopsworks-web/yo/app/scripts/controllers/zeppelinCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/zeppelinCtrl.js
@@ -318,6 +318,8 @@ angular.module('hopsWorksApp')
               if (op === 'CREATED_SOCKET') {
                 load();
                 loaded = true;
+	      } else if (op === 'ERROR_INFO') {
+		growl.error(payload.data.info, {title: 'Error', ttl: 5000, referenceId: 10});
               } else if (loaded && op === 'NOTES_INFO') {
                 self.notes = payload.data.notes;
                 setNotes(self.notes);

--- a/hopsworks-web/yo/app/views/zeppelinDashboard.html
+++ b/hopsworks-web/yo/app/views/zeppelinDashboard.html
@@ -32,7 +32,7 @@
                 <a class="fa fa-undo" aria-hidden="true" style="text-decoration: none" ng-click="zeppelinCtrl.restoreAll()"></a>
               </span>
               <span ng-if="zeppelinCtrl.pathArray.includes(zeppelinCtrl.TRASH_FOLDER_ID)" style=" margin-right: 10px;" title="Empty trash">
-                <a class="fa fa fa-times" aria-hidden="true" style="text-decoration: none" ng-click="zeppelinCtrl.emptyTrash()"></a>
+                <a class="fa fa-trash" aria-hidden="true" style="text-decoration: none" ng-click="zeppelinCtrl.emptyTrash()"></a>
               </span>
               <span ng-show="zeppelinCtrl.pathArray.length > 10">...</span>
               <span data-ng-repeat="path in zeppelinCtrl.pathArray.slice(zeppelinCtrl.pathArray.length - 1 - zeppelinCtrl.breadcrumbLen()) track by $index">


### PR DESCRIPTION
* Add project generic user as owner of notebook

* Allow every member to move notes to Trash but only the Data Owner can empty the Trash

* Log activity of moving Notebooks to Zeppelin Trash

* Change Zeppelin Empty trash icon :)

* Zeppelin UI handles the error message. Hopsworks should handle it somehow...

* Handle error message in Hopsworks UI

* Change log severity for exception thrown when user does not have permissions to empty the Trash bin