### PR TITLE
HOPSWORKS-382 - conda channel support

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDepJson.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDepJson.java
@@ -18,6 +18,7 @@ public class PythonDepJson {
    * @param channelUrl
    * @param lib
    * @param version 
+   * @param status 
    */
   public PythonDepJson(String channelUrl, String lib, String version, String 
           preinstalled, String status) {

--- a/hopsworks-web/yo/Gruntfile.js
+++ b/hopsworks-web/yo/Gruntfile.js
@@ -417,7 +417,7 @@ module.exports = function (grunt) {
 
     grunt.task.run([
       'clean:server',
-      'wiredep',
+     // 'wiredep',
       'concurrent:server',
       'autoprefixer:server',
       'connect:livereload',
@@ -441,7 +441,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build', [
     'clean:dist',
-    'wiredep',
+   // 'wiredep',
     'useminPrepare',
     'concurrent:dist',
     'autoprefixer',

--- a/hopsworks-web/yo/app/scripts/controllers/pythonDepsCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/pythonDepsCtrl.js
@@ -45,10 +45,11 @@ angular.module('hopsWorksApp')
 
 
 //            https://repo.continuum.io/pkgs/free/linux-64/
+            self.condaChannel = "default";
             self.condaUrl = "default";
             self.selectedLibs = {};
 
-            self.selectedLib = {"channelUrl": self.condaUrl,
+            self.selectedLib = {"channelUrl": self.condaChannel,
               "lib": "", "version": ""};
 
             self.progress = function () {
@@ -198,6 +199,7 @@ angular.module('hopsWorksApp')
               if (self.selectedLib.lib.length < 3) {
                 return;
               }
+              self.selectedLib.channelUrl = self.condaChannel;
               self.searching = true;
               self.resultsMsg = "Conda searching can take a good few seconds......bear with us.";
               self.resultsMessageShowing = true;
@@ -238,7 +240,7 @@ angular.module('hopsWorksApp')
 
               self.installing[host][lib] = true;
 
-              var data = {"channelUrl": self.condaUrl, "lib": lib, "version": version.version};
+              var data = {"channelUrl": self.condaChannel, "lib": lib, "version": version.version};
 
               PythonDepsService.installOneHost(self.projectId, host, data).then(
                       function (success) {
@@ -258,7 +260,7 @@ angular.module('hopsWorksApp')
               }
               self.installing[lib] = true;
 
-              var data = {"channelUrl": self.condaUrl, "lib": lib, "version": version.version};
+              var data = {"channelUrl": self.condaChannel, "lib": lib, "version": version.version};
 
               PythonDepsService.install(self.projectId, data).then(
                       function (success) {
@@ -273,10 +275,10 @@ angular.module('hopsWorksApp')
               });
             };
 
-            self.uninstall = function (condaUrl, lib, version) {
+            self.uninstall = function (condaChannel, lib, version) {
               self.uninstalling[lib] = true;
 
-              var data = {"channelUrl": condaUrl, "lib": lib, "version": version};
+              var data = {"channelUrl": condaChannel, "lib": lib, "version": version};
               PythonDepsService.uninstall(self.projectId, data).then(
                       function (success) {
                         self.getInstalled();
@@ -287,10 +289,10 @@ angular.module('hopsWorksApp')
               });
             };
 
-            self.upgrade = function (condaUrl, lib, version) {
+            self.upgrade = function (condaChannel, lib, version) {
               self.upgrading[lib] = true;
 
-              var data = {"channelUrl": condaUrl, "lib": lib, "version": version};
+              var data = {"channelUrl": condaChannel, "lib": lib, "version": version};
               PythonDepsService.upgrade(self.projectId, data).then(
                       function (success) {
                         growl.success("Sending command to update: " + lib, {title: 'Updating', ttl: 3000});

--- a/hopsworks-web/yo/app/views/projectSettings.html
+++ b/hopsworks-web/yo/app/views/projectSettings.html
@@ -216,7 +216,7 @@
                   <div ng-show="pythonDepsCtrl.enabled" class="control-group col-md-offset-1">
                     <div style="margin-top: 5px;">
                       <div>Conda Channel: <a uib-tooltip="You can search a different conda channel by entering a new channel name here." tooltip-placement="top"
-                                         href="#" data-inputclass="xwdith" editable-text="pythonDepsCtrl.condaChannel">{{ pythonDepsCtrl.condaChannel || 'empty' }}</a></div>  
+                                         href="#" data-inputclass="xwdith" editable-text="pythonDepsCtrl.condaChannel">{{ pythonDepsCtrl.condaChannel || 'default' }}</a></div>  
                       
 <!--                      <div>Conda URL: <a uib-tooltip="You can search a different conda repository by entering a new URL for a channel here." tooltip-placement="top"
                                          href="#" data-inputclass="xwdith" editable-url="pythonDepsCtrl.condaUrl">{{ pythonDepsCtrl.condaUrl || 'empty' }}</a></div>  -->

--- a/hopsworks-web/yo/app/views/projectSettings.html
+++ b/hopsworks-web/yo/app/views/projectSettings.html
@@ -215,8 +215,11 @@
                 <fieldset>
                   <div ng-show="pythonDepsCtrl.enabled" class="control-group col-md-offset-1">
                     <div style="margin-top: 5px;">
-                      <div>Conda URL: <a uib-tooltip="You can search a different conda repository by entering a new URL for a channel here." tooltip-placement="top"
-                                         href="#" data-inputclass="xwdith" editable-url="pythonDepsCtrl.condaUrl">{{ pythonDepsCtrl.condaUrl || 'empty' }}</a></div>  
+                      <div>Conda Channel: <a uib-tooltip="You can search a different conda channel by entering a new channel name here." tooltip-placement="top"
+                                         href="#" data-inputclass="xwdith" editable-text="pythonDepsCtrl.condaChannel">{{ pythonDepsCtrl.condaChannel || 'empty' }}</a></div>  
+                      
+<!--                      <div>Conda URL: <a uib-tooltip="You can search a different conda repository by entering a new URL for a channel here." tooltip-placement="top"
+                                         href="#" data-inputclass="xwdith" editable-url="pythonDepsCtrl.condaUrl">{{ pythonDepsCtrl.condaUrl || 'empty' }}</a></div>  -->
                       <!--                          <input id="condaurl" ng-trim="false" class="form-control" 
                                                        type="text" required y
                                                        ng-pattern="/^\s*\w*\s*$/"

--- a/hopsworks-web/yo/bower.json
+++ b/hopsworks-web/yo/bower.json
@@ -36,7 +36,7 @@
     "angular-tour": "^0.2.5",
     "angular-resizable": "^1.2.0",
     "v-accordion": "^1.6.0",
-    "angular-smart-table": "^2.1.8",
+    "angular-smart-table": "^2.1.9",
     "ng-context-menu": "^1.0.3",
     "ng-flow": "^2.7.4",
     "angular-growl-v2": "^0.7.9",
@@ -71,7 +71,6 @@
     "angular-bootstrap": "^2.1.3",
     "eonasdan-bootstrap-datetimepicker": "^4.17.42",
     "angular-ui-select": "^0.19.6",
-    "angular-smart-table": "^2.1.8",
     "angular-aria": "^1.4.8",
     "angular-xeditable": "^0.2.0",
     "jquery": "2.0.3"


### PR DESCRIPTION
This also fixes the problem with angular-smart-table.js disappearing, by removing the Grunt task 'wiredep'.

https://hopshadoop.atlassian.net/browse/HOPSWORKS-382