### PR TITLE
[HOPSWORKS-396]  

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -98,7 +98,7 @@ public class CertificateMaterializer {
     TIME_SUFFIXES.put("d", TimeUnit.DAYS);
   }
   
-  private final String CERT_PASS_SUFFIX = "__cert.key";
+  public static final String CERT_PASS_SUFFIX = "__cert.key";
   
   private final Map<MaterialKey, InternalCryptoMaterial> materialMap =
       new ConcurrentHashMap<>();

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/HopsUtils.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/HopsUtils.java
@@ -253,8 +253,11 @@ public class HopsUtils {
       + username + Path.SEPARATOR + username + "__kstore.jks");
     Path remoteProjectDirT = new Path(remoteFSDir + Path.SEPARATOR
         + username + Path.SEPARATOR + username + "__tstore.jks");
+    Path remoteProjectDirP = new Path(remoteFSDir + Path.SEPARATOR + username + Path.SEPARATOR + username +
+        CertificateMaterializer.CERT_PASS_SUFFIX);
     dfso.rm(remoteProjectDirK, false);
     dfso.rm(remoteProjectDirT, false);
+    dfso.rm(remoteProjectDirP, false);
   }
   
   /**


### PR DESCRIPTION
Remove certificate password file from HDFS when doing cleanup for Zeppelin and Jupyter

https://hopshadoop.atlassian.net/browse/HOPSWORKS-396