### PR TITLE
HOPSWORKS-405 do not retry failed TensorFlow tasks

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfig.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfig.java
@@ -395,7 +395,8 @@ public class JupyterConfig {
                   "exec_timeout", (isTensorFlowOnSpark) ?
                                   Integer.toString(((js.getNumExecutors() + js.getNumTfPs()) * 15) + 60 ) + "s":
                                   "60s",
-                  "extra_java_options", extraJavaOptions
+                  "extra_java_options", extraJavaOptions,
+                  "max_failures", (isHorovod || isTensorFlow || isTensorFlowOnSpark) ? "1": "4"
               );
       createdSparkmagic = ConfigFileGenerator.createConfigFile(
           sparkmagic_config_file,

--- a/hopsworks-common/src/main/resources/io/hops/jupyter/config_template.json
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/config_template.json
@@ -89,7 +89,8 @@
       "spark.dynamicAllocation.minExecutors": "%%min_executors%%",
       "spark.dynamicAllocation.maxExecutors": "%%max_executors%%",
       "spark.dynamicAllocation.executorIdleTimeout": "%%exec_timeout%%",
-      "spark.metrics.conf": "%%metrics_path%%"
+      "spark.metrics.conf": "%%metrics_path%%",
+      "spark.task.maxFailures": "%%max_failures%%"
     }
   },
   "use_auto_viz": true,


### PR DESCRIPTION
do not retry failed TensorFlow tasks, resulting in faster feedback when TensorFlow code fails