### PR TITLE
[HOPSWORKS-333]  Configure logging for libhdfs Java upcalls

### DIFF
--- a/hopsworks-common/src/main/resources/io/hops/jupyter/config_template.json
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/config_template.json
@@ -27,7 +27,7 @@
     "loggers": {
       "magicsLogger": {
         "handlers": ["magicsHandler"],
-        "level": "DEBUG",
+        "level": "WARN",
         "propagate": 0
       }
     }
@@ -59,7 +59,7 @@
       "spark.yarn.appMasterEnv.LD_LIBRARY_PATH": "%%java_home%%/jre/lib/amd64/server:%%cuda_dir%%/lib64:%%hadoop_home%%/lib/native",
       "spark.yarn.appMasterEnv.CUDA_VISIBLE_DEVICES": "",
       "spark.yarn.appMasterEnv.HADOOP_HOME": "%%hadoop_home%%",
-      "spark.yarn.appMasterEnv.LIBHDFS_OPTS": "-Xmx96m",
+      "spark.yarn.appMasterEnv.LIBHDFS_OPTS": "-Xmx96m -Dlog4j.configuration=%%hadoop_home%%/etc/hadoop/log4j.properties -Dhadoop.root.logger=WARN,RFA",
       "spark.yarn.appMasterEnv.HADOOP_HDFS_HOME": "%%hadoop_home%%",
       "spark.yarn.appMasterEnv.HADOOP_VERSION": "%%hadoop_version%%",
       "spark.yarn.appMasterEnv.HADOOP_USER_NAME": "%%hdfs_user%%",
@@ -72,7 +72,7 @@
       "spark.executorEnv.MPI_NP": "%%mpi_np%%",
       "spark.executorEnv.HADOOP_USER_NAME": "%%hdfs_user%%",
       "spark.executorEnv.HADOOP_HOME": "%%hadoop_home%%",
-      "spark.executorEnv.LIBHDFS_OPTS": "-Xmx96m",
+      "spark.executorEnv.LIBHDFS_OPTS": "-Xmx96m -Dlog4j.configuration=%%hadoop_home%%/etc/hadoop/log4j.properties -Dhadoop.root.logger=WARN,RFA",
       "spark.executorEnv.PYSPARK_PYTHON": "%%pyspark_bin%%",
       "spark.executorEnv.PYSPARK3_PYTHON": "%%pyspark_bin%%",
       "spark.executorEnv.LD_LIBRARY_PATH": "%%java_home%%/jre/lib/amd64/server:%%cuda_dir%%/lib64:%%hadoop_home%%/lib/native",

--- a/hopsworks-common/src/main/resources/io/hops/jupyter/jupyter_notebook_config_template.py
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/jupyter_notebook_config_template.py
@@ -29,6 +29,8 @@ c.NotebookApp.iopub_data_rate_limit=10000000
 
 c.NotebookApp.base_url='/hopsworks-api/jupyter/%%port%%/'
 
+c.Application.log_level="WARN"
+
 
 c.JupyterConsoleApp.kernel_name="PySpark"
 


### PR DESCRIPTION
If log level is set to DEBUG, then Livy server running on the driver cannot serialize the message. The problem exists for Jackson databind library > 2.2.4