### PR TITLE
[HOPSWORKS-413-UI_fix] Use title instead of placeholder for extra Spark properties in Jupyter

### DIFF
--- a/hopsworks-web/yo/app/views/jupyterDashboard.html
+++ b/hopsworks-web/yo/app/views/jupyterDashboard.html
@@ -357,7 +357,7 @@
                 <div class="col-md-5 jupyter-left">
                   <textarea style="width: 100%;" id="TextArea" ng-model="jupyterCtrl.val.sparkParams" 
                             ng-keyup="autoExpand($event)" 
-                            placeholder="spark.yarn.am.port=12242&#10;spark.driver.extraLibraryPath=/path/to/extra/library">
+                            title="spark.yarn.am.port=12242&#10;spark.driver.extraLibraryPath=/path/to/extra/library">
                   </textarea>
                 </div>
 


### PR DESCRIPTION
[HOPSWORKS-413-UI_fix]  Use title instead of placeholder since Firefox has a bug and does not render the new line symbol

Firefox has a bug (https://bugzilla.mozilla.org/show_bug.cgi?id=1391044) and does not render the new line symbol for placeholder in textarea element, although it should according to the specification. Using title instead.