### PR TITLE
[HOPSWORKS-438]  Materialize certificates locally

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/dto/MaterializerStateResponse.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/dto/MaterializerStateResponse.java
@@ -22,47 +22,59 @@ package io.hops.hopsworks.api.admin.dto;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.List;
-import java.util.Set;
 
 @XmlRootElement
 public class MaterializerStateResponse implements Serializable {
   private static final long serialVersionUID = 1L;
   
-  private List<CryptoMaterial> materializedState;
-  private Set<String> scheduledRemovals;
+  private List<CryptoMaterial> localMaterializedState;
+  private List<CryptoMaterial> remoteMaterializedState;
+  private List<CryptoMaterial> scheduledRemovals;
   
   public MaterializerStateResponse(
-      List<CryptoMaterial> materializedState, Set<String> scheduledRemovals) {
-    this.materializedState = materializedState;
+      List<CryptoMaterial> localMaterializedState, List<CryptoMaterial> remoteMaterializedState,
+      List<CryptoMaterial> scheduledRemovals) {
+    this.localMaterializedState = localMaterializedState;
+    this.remoteMaterializedState = remoteMaterializedState;
     this.scheduledRemovals = scheduledRemovals;
   }
   
   public MaterializerStateResponse() {
   }
   
-  public List<CryptoMaterial> getMaterializedState() {
-    return materializedState;
+  public List<CryptoMaterial> getLocalMaterializedState() {
+    return localMaterializedState;
   }
   
-  public void setMaterializedState(
-      List<CryptoMaterial> materializedState) {
-    this.materializedState = materializedState;
+  public void setLocalMaterializedState(
+      List<CryptoMaterial> localMaterializedState) {
+    this.localMaterializedState = localMaterializedState;
   }
   
-  public Set<String> getScheduledRemovals() {
+  public List<CryptoMaterial> getRemoteMaterializedState() {
+    return remoteMaterializedState;
+  }
+  
+  public void setRemoteMaterializedState(List<CryptoMaterial> remoteMaterializedState) {
+    this.remoteMaterializedState = remoteMaterializedState;
+  }
+  
+  public List<CryptoMaterial> getScheduledRemovals() {
     return scheduledRemovals;
   }
   
-  public void setScheduledRemovals(Set<String> scheduledRemovals) {
+  public void setScheduledRemovals(List<CryptoMaterial> scheduledRemovals) {
     this.scheduledRemovals = scheduledRemovals;
   }
   
   public static class CryptoMaterial {
     private String user;
+    private String path;
     private Integer references;
     
-    public CryptoMaterial(String user, Integer references) {
+    public CryptoMaterial(String user, String path, Integer references) {
       this.user = user;
+      this.path = path;
       this.references = references;
     }
     
@@ -75,6 +87,14 @@ public class MaterializerStateResponse implements Serializable {
     
     public void setUser(String user) {
       this.user = user;
+    }
+    
+    public String getPath() {
+      return path;
+    }
+    
+    public void setPath(String path) {
+      this.path = path;
     }
     
     public Integer getReferences() {

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/jupyter/JupyterService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/jupyter/JupyterService.java
@@ -295,12 +295,12 @@ public class JupyterService {
           throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
               "Incomplete request!");
         }
-        HopsUtils.materializeCertificatesForUser(project.getName(), project_user[1], settings.getHopsworksTmpCertDir(),
-            settings.getHdfsTmpCertDir(), dfso, certificateMaterializer, settings);
+        HopsUtils.materializeCertificatesForUser(project.getName(), project_user[1], settings.getHdfsTmpCertDir(),
+            dfso, certificateMaterializer, settings);
       } catch (InterruptedException | IOException ex) {
         Logger.getLogger(JupyterService.class.getName()).log(Level.SEVERE, null, ex);
         try {
-          HopsUtils.cleanupCertificatesForUser(project_user[1], project.getName(), settings.getHdfsTmpCertDir(), dfso,
+          HopsUtils.cleanupCertificatesForUser(project_user[1], project.getName(), settings.getHdfsTmpCertDir(),
               certificateMaterializer);
         } catch (IOException e) {
           LOGGER.log(Level.SEVERE, "Could not cleanup certificates for " + hdfsUser);
@@ -391,8 +391,7 @@ public class JupyterService {
     DistributedFileSystemOps dfso = dfsService.getDfsOps();
     try {
       HopsUtils.cleanupCertificatesForUser(project_user[1], project
-          .getName(), settings.getHdfsTmpCertDir(), dfso,
-          certificateMaterializer);
+          .getName(), settings.getHdfsTmpCertDir(), certificateMaterializer);
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "Could not cleanup certificates for " + hdfsUser);
     } finally {

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/InterpreterRestApi.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/InterpreterRestApi.java
@@ -31,7 +31,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
 import io.hops.hopsworks.common.hdfs.DistributedFsService;
 import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.util.HopsUtils;
@@ -264,14 +263,12 @@ public class InterpreterRestApi {
   }
   
   private void cleanUserCertificates(Project project) {
-    DistributedFileSystemOps dfso = null;
     try {
       if (!areRunningInterpretersForProject(project)) {
         
-        dfso = dfsService.getDfsOps();
         HopsUtils
             .cleanupCertificatesForProject(project.getName(),
-                settings.getHdfsTmpCertDir(), dfso, certificateMaterializer);
+                settings.getHdfsTmpCertDir(), certificateMaterializer);
         certificateMaterializer.closedInterpreter(project.getId());
       }
     } catch (IOException ex) {
@@ -279,17 +276,12 @@ public class InterpreterRestApi {
     } catch (AppException ex) {
       logger.error("Exception while trying to get running interpreters for project: " + project.getName()
           + " Cleaning certificates...", ex);
-      dfso = dfsService.getDfsOps();
       try {
         certificateMaterializer.closedInterpreter(project.getId());
-        HopsUtils.cleanupCertificatesForProject(project.getName(), settings.getHdfsTmpCertDir(), dfso,
+        HopsUtils.cleanupCertificatesForProject(project.getName(), settings.getHdfsTmpCertDir(),
             certificateMaterializer);
       } catch (IOException ex1) {
         logger.error("Could not clean certificates!", ex1);
-      }
-    } finally {
-      if (null != dfso) {
-        dfso.close();
       }
     }
   }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/NotebookRestApi.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/NotebookRestApi.java
@@ -628,14 +628,13 @@ public class NotebookRestApi {
           if (certificateMaterializer.openedInterpreter(project.getId())) {
             try {
               HopsUtils.materializeCertificatesForProject(project.getName(),
-                  settings.getHopsworksTmpCertDir(), settings.getHdfsTmpCertDir(),
-                  dfso, certificateMaterializer, settings);
+                  settings.getHdfsTmpCertDir(), dfso, certificateMaterializer, settings);
             } catch (IOException ex) {
               LOG.warn("Could not materialize certificates for user: " +
                   project.getName() + "__" + username);
               certificateMaterializer.closedInterpreter(project.getId());
               HopsUtils.cleanupCertificatesForProject(project.getName(),
-                  settings.getHdfsTmpCertDir(), dfso, certificateMaterializer);
+                  settings.getHdfsTmpCertDir(), certificateMaterializer);
               throw ex;
             }
           }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServer.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServer.java
@@ -36,6 +36,7 @@ import javax.ejb.ConcurrencyManagement;
 import javax.ejb.ConcurrencyManagementType;
 import javax.ejb.EJB;
 
+import io.hops.hopsworks.common.security.CertificateMaterializer;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.commons.lang.StringUtils;
@@ -59,7 +60,6 @@ import io.hops.hopsworks.common.dao.jobs.quota.YarnProjectsQuotaFacade;
 import io.hops.hopsworks.common.dao.project.PaymentType;
 import io.hops.hopsworks.common.exception.AppException;
 import io.hops.hopsworks.common.hdfs.DistributedFsService;
-import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.util.Settings;
 import java.util.Date;
 import javax.ws.rs.core.Response;

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServerImpl.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServerImpl.java
@@ -1615,14 +1615,13 @@ public class NotebookServerImpl implements
       try {
         dfso = dfsService.getDfsOps();
         HopsUtils.materializeCertificatesForProject(project.getName(),
-            settings.getHopsworksTmpCertDir(),
             settings.getHdfsTmpCertDir(), dfso, certificateMaterializer,
             settings);
       } catch (IOException ex) {
         LOG.log(Level.SEVERE, "Error while materializing certificates for Zeppelin", ex);
         certificateMaterializer.closedInterpreter(project.getId());
-        HopsUtils.cleanupCertificatesForProject(project.getName(),
-            settings.getHdfsTmpCertDir(), dfso, certificateMaterializer);
+        HopsUtils.cleanupCertificatesForProject(project.getName(), settings.getHdfsTmpCertDir(),
+            certificateMaterializer);
         throw ex;
       } finally {
         if (null != dfso) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/kafka/KafkaFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/kafka/KafkaFacade.java
@@ -42,8 +42,8 @@ import javax.persistence.TypedQuery;
 import javax.ws.rs.core.Response;
 
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
-import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.security.BaseHadoopClientsService;
+import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.util.Settings;
 import kafka.admin.AdminUtils;
 import kafka.admin.RackAwareMode;
@@ -947,7 +947,7 @@ public class KafkaFacade {
             + brokerAddress, ex);
       }
     } finally {
-      certificateMaterializer.removeCertificate(user.getUsername(), project.getName());
+      certificateMaterializer.removeCertificatesLocal(user.getUsername(), project.getName());
     }
     Collections.sort(partitionDetails, (PartitionDetailsDTO c1, PartitionDetailsDTO c2) -> {
         if (c1.getId() < c2.getId()) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/AsynchronousJobExecutor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/AsynchronousJobExecutor.java
@@ -35,8 +35,8 @@ import java.io.IOException;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 
-import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.security.BaseHadoopClientsService;
+import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.util.Settings;
 import io.hops.hopsworks.common.yarn.YarnClientService;
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
@@ -87,8 +87,8 @@ import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
 import io.hops.hopsworks.common.hdfs.DistributedFsService;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
 import io.hops.hopsworks.common.message.MessageController;
-import io.hops.hopsworks.common.security.CertificatesController;
 import io.hops.hopsworks.common.security.CertificateMaterializer;
+import io.hops.hopsworks.common.security.CertificatesController;
 import io.hops.hopsworks.common.jobs.yarn.YarnLogUtil;
 import io.hops.hopsworks.common.security.CertificatesMgmService;
 import io.hops.hopsworks.common.util.HopsUtils;
@@ -937,9 +937,8 @@ public class ProjectController {
     }
 
     cleanup(project, sessionId);
-    certificateMaterializer.forceRemoveCertificates(user.getUsername(),
-        project.getName(), true);
-
+    
+    certificateMaterializer.forceRemoveLocalMaterial(user.getUsername(), project.getName(), null, true);
     if (settings.isPythonKernelEnabled()) {
       jupyterProcessFacade.removePythonKernelsForProject(project.getName());
     }
@@ -2022,9 +2021,8 @@ public class ProjectController {
 
     logActivity(ActivityFacade.REMOVED_MEMBER + toRemoveEmail,
         ActivityFacade.FLAG_PROJECT, user, project);
-
-    certificateMaterializer.forceRemoveCertificates(userToBeRemoved
-        .getUsername(), project.getName(), false);
+    
+    certificateMaterializer.forceRemoveLocalMaterial(userToBeRemoved.getUsername(), project.getName(), null, false);
     certificatesController.deleteUserSpecificCertificates(project, userToBeRemoved);
   }
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/AcquireLockException.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/AcquireLockException.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of HopsWorks
+ *
+ * Copyright (C) 2013 - 2018, Logical Clocks AB and RISE SICS AB. All rights reserved.
+ *
+ * HopsWorks is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HopsWorks is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with HopsWorks.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.hops.hopsworks.common.security;
+
+/**
+ * Exception thrown in {@link CertificateMaterializer} when operating on remote material and cannot acquire a lock in
+ * the database
+ */
+public class AcquireLockException extends Exception {
+  public AcquireLockException() {
+    super();
+  }
+  
+  public AcquireLockException(String message) {
+    super(message);
+  }
+  
+  public AcquireLockException(Throwable cause) {
+    super(cause);
+  }
+  
+  public AcquireLockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/BaseHadoopClientsService.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/BaseHadoopClientsService.java
@@ -140,7 +140,7 @@ public class BaseHadoopClientsService {
             " specific, nor project generic!");
       }
       
-      return cryptoMaterial.getPassword();
+      return new String(cryptoMaterial.getPassword());
     }
     
     throw new RuntimeException("Username cannot be null!");
@@ -164,7 +164,7 @@ public class BaseHadoopClientsService {
       if (pguMatcher.matches()) {
         String pguUsername = pguMatcher.group(1);
         try {
-          certificateMaterializer.materializeCertificates(pguUsername);
+          certificateMaterializer.materializeCertificatesLocal(pguUsername);
         } catch (IOException ex) {
           throw new RuntimeException("Error while materializing project " +
               "generic user certificates " + ex.getMessage(), ex);
@@ -173,7 +173,7 @@ public class BaseHadoopClientsService {
         String[] tokens = username.split(HdfsUsersController.USER_NAME_DELIMITER, 2);
         if (tokens.length == 2) {
           try {
-            certificateMaterializer.materializeCertificates(tokens[1], tokens[0]);
+            certificateMaterializer.materializeCertificatesLocal(tokens[1], tokens[0]);
           } catch (IOException ex) {
             throw new RuntimeException("Error while materializing " +
                 "user certificates " + ex.getMessage(), ex);
@@ -191,11 +191,11 @@ public class BaseHadoopClientsService {
       Matcher pguMatcher = projectGenericUserPatter.matcher(username);
       if (pguMatcher.matches()) {
         String pguUsername = pguMatcher.group(1);
-        certificateMaterializer.removeCertificate(pguUsername);
+        certificateMaterializer.removeCertificatesLocal(pguUsername);
       } else if (username.matches(HopsSSLSocketFactory.USERNAME_PATTERN)) {
         String[] tokens = username.split(HdfsUsersController.USER_NAME_DELIMITER, 2);
         if (tokens.length == 2) {
-          certificateMaterializer.removeCertificate(tokens[1], tokens[0]);
+          certificateMaterializer.removeCertificatesLocal(tokens[1], tokens[0]);
         }
       } else {
         throw new RuntimeException("User <" + username +"> is neither project" +

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -18,8 +18,6 @@
  */
 package io.hops.hopsworks.common.security;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.hops.hopsworks.common.dao.certificates.CertsFacade;
 import io.hops.hopsworks.common.dao.certificates.ProjectGenericUserCerts;
 import io.hops.hopsworks.common.dao.certificates.UserCerts;
@@ -28,25 +26,35 @@ import io.hops.hopsworks.common.dao.project.ProjectFacade;
 import io.hops.hopsworks.common.dao.user.UserFacade;
 import io.hops.hopsworks.common.dao.user.Users;
 import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
+import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
+import io.hops.hopsworks.common.hdfs.DistributedFsService;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
+import io.hops.hopsworks.common.security.dao.RemoteMaterialRefID;
+import io.hops.hopsworks.common.security.dao.RemoteMaterialReferences;
 import io.hops.hopsworks.common.util.HopsUtils;
 import io.hops.hopsworks.common.util.Settings;
+import org.apache.commons.collections.Bag;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections.bag.HashBag;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
-import javax.ejb.AccessTimeout;
 import javax.ejb.ConcurrencyManagement;
 import javax.ejb.ConcurrencyManagementType;
 import javax.ejb.DependsOn;
 import javax.ejb.EJB;
-import javax.ejb.Lock;
-import javax.ejb.LockType;
 import javax.ejb.Singleton;
 import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
@@ -54,41 +62,23 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Singleton
-@ConcurrencyManagement(ConcurrencyManagementType.CONTAINER)
+@ConcurrencyManagement(ConcurrencyManagementType.BEAN)
 @DependsOn("Settings")
 public class CertificateMaterializer {
-  
-  private final Logger LOG = Logger.getLogger(CertificateMaterializer
-      .class.getName());
-  
-  @EJB
-  private CertsFacade certsFacade;
-  @EJB
-  private Settings settings;
-  @EJB
-  private UserFacade userFacade;
-  @EJB
-  private ProjectFacade projectFacade;
-  @EJB
-  private HdfsUsersController hdfsUsersController;
-  @EJB
-  private CertificatesMgmService certificatesMgmService;
-  @Resource
-  private ManagedScheduledExecutorService scheduler;
-  
+  private static final Logger LOG = Logger.getLogger(CertificateMaterializer.class.getName());
   private static final Map<String, TimeUnit> TIME_SUFFIXES;
   static {
     TIME_SUFFIXES = new HashMap<>(5);
@@ -98,20 +88,60 @@ public class CertificateMaterializer {
     TIME_SUFFIXES.put("h", TimeUnit.HOURS);
     TIME_SUFFIXES.put("d", TimeUnit.DAYS);
   }
+  private final static String KEYSTORE_SUFFIX = "__kstore.jks";
+  private final static String TRUSTSTORE_SUFFIX = "__tstore.jks";
+  private final static String CERT_PASS_SUFFIX = "__cert.key";
+  private final static Pattern HDFS_SCHEME = Pattern.compile("^hdfs://.*");
+  private final static int MAX_NUMBER_OF_RETRIES = 3;
+  private final static long RETRY_WAIT_TIMEOUT = 10;
   
-  public static final String CERT_PASS_SUFFIX = "__cert.key";
+  private final Map<MaterialKey, Bag> materializedCerts;
+  private final Map<MaterialKey, CryptoMaterial> materialCache;
+  private final Map<MaterialKey, Map<String, Runnable>> fileRemovers;
+  private final ReentrantReadWriteLock localLock;
+  private final ReentrantReadWriteLock.ReadLock localReadLock;
+  private final ReentrantReadWriteLock.WriteLock localWriteLock;
+  private final ReentrantReadWriteLock remoteLock;
+  private final ReentrantReadWriteLock.ReadLock remoteReadLock;
+  private final ReentrantReadWriteLock.WriteLock remoteWriteLock;
+  private final Set<Integer> projectsWithOpenInterpreters;
   
-  private final Map<MaterialKey, InternalCryptoMaterial> materialMap =
-      new ConcurrentHashMap<>();
+  private String lock_id;
   
-  private final Set<Integer> projectsWithOpenInterpreters = new ConcurrentSkipListSet<>();
-  private final Map<MaterialKey, FileRemover> scheduledFileRemovers =
-      new ConcurrentHashMap<>();
   private String transientDir;
   private Long DELAY_VALUE;
   private TimeUnit DELAY_TIMEUNIT;
   
+  @EJB
+  private Settings settings;
+  @EJB
+  private CertsFacade certsFacade;
+  @EJB
+  private ProjectFacade projectFacade;
+  @EJB
+  private HdfsUsersController hdfsUsersController;
+  @EJB
+  private UserFacade userFacade;
+  @EJB
+  private CertificatesMgmService certificatesMgmService;
+  @EJB
+  private RemoteMaterialReferencesFacade remoteMaterialReferencesFacade;
+  @EJB
+  private DistributedFsService distributedFsService;
+  @Resource
+  private ManagedScheduledExecutorService scheduler;
+  
   public CertificateMaterializer() {
+    materializedCerts = new HashMap<>();
+    materialCache = new HashMap<>();
+    fileRemovers = new HashMap<>();
+    localLock = new ReentrantReadWriteLock(true);
+    localReadLock = localLock.readLock();
+    localWriteLock = localLock.writeLock();
+    remoteLock = new ReentrantReadWriteLock(true);
+    remoteWriteLock = remoteLock.writeLock();
+    remoteReadLock = remoteLock.readLock();
+    projectsWithOpenInterpreters = new ConcurrentSkipListSet<>();
   }
   
   @PostConstruct
@@ -119,9 +149,9 @@ public class CertificateMaterializer {
     File tmpDir = new File(settings.getHopsworksTmpCertDir());
     if (!tmpDir.exists()) {
       throw new IllegalStateException("Transient certificates directory <" +
-        tmpDir.getAbsolutePath() + "> does NOT exist!");
+          tmpDir.getAbsolutePath() + "> does NOT exist!");
     }
-  
+    
     try {
       PosixFileAttributeView fileView = Files.getFileAttributeView(tmpDir
           .toPath(), PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
@@ -132,20 +162,20 @@ public class CertificateMaterializer {
           .OWNER_WRITE);
       boolean ownerExecute = permissions.contains(PosixFilePermission
           .OWNER_EXECUTE);
-    
+      
       boolean groupRead = permissions.contains(PosixFilePermission.GROUP_READ);
       boolean groupWrite = permissions.contains(PosixFilePermission
           .GROUP_WRITE);
       boolean groupExecute = permissions.contains(PosixFilePermission
           .GROUP_EXECUTE);
-    
+      
       boolean othersRead = permissions.contains(PosixFilePermission
           .OTHERS_READ);
       boolean othersWrite = permissions.contains(PosixFilePermission
           .OTHERS_WRITE);
       boolean othersExecute = permissions.contains(PosixFilePermission
           .OTHERS_EXECUTE);
-    
+      
       // Permissions should be 750
       if ((ownerRead && ownerWrite && ownerExecute)
           && (groupRead && !groupWrite && groupExecute)
@@ -177,7 +207,7 @@ public class CertificateMaterializer {
     }
     transientDir = tmpDir.getAbsolutePath();
     String delayRaw = settings.getCertificateMaterializerDelay();
-  
+    
     Matcher matcher = Pattern.compile("([0-9]+)([a-z]+)?").matcher(delayRaw
         .toLowerCase());
     if (!matcher.matches()) {
@@ -191,6 +221,15 @@ public class CertificateMaterializer {
     }
     DELAY_TIMEUNIT = timeUnitStr == null ? TimeUnit.MINUTES : TIME_SUFFIXES
         .get(timeUnitStr);
+    
+    try {
+      String hostAddress = InetAddress.getLocalHost().getHostAddress();
+      long threadId = Thread.currentThread().getId();
+      String lock_identifier = hostAddress + "_" + threadId;
+      lock_id = lock_identifier.length() <= 30 ? lock_identifier : lock_identifier.substring(0, 30);
+    } catch (UnknownHostException ex) {
+      throw new IllegalStateException(ex);
+    }
   }
   
   @PreDestroy
@@ -199,219 +238,424 @@ public class CertificateMaterializer {
       FileUtils.cleanDirectory(new File(transientDir));
     } catch (IOException ex) {
       LOG.log(Level.SEVERE, "Could not clean directory " + transientDir
-        + " Administrator should clean it manually!", ex);
+          + " Administrator should clean it manually!", ex);
     }
   }
   
-  public void materializeCertificates(String projectName) throws IOException {
-    materializeCertificates(null, projectName);
-  }
-
-  @Lock(LockType.WRITE)
-  @AccessTimeout(value=500)
-  public void materializeCertificates(String username, String projectName)
-    throws IOException {
-    MaterialKey key = new MaterialKey(username, projectName);
-    InternalCryptoMaterial material = materialMap.get(key);
-    FileRemover scheduledRemover = null;
-    LOG.log(Level.FINEST, "Requested materialization for: " + key
-        .getExtendedUsername());
-    if (material != null) {
-      // Crypto material already exists
-      material.incrementReference();
-      LOG.log(Level.FINEST, "User: " + key.getExtendedUsername() + " " +
-          "Material exist, ref " + material.references);
-    } else {
-      // Crypto material does not exist in cache
-      LOG.log(Level.FINEST, "Material for " + key.getExtendedUsername()
-          + " does not exist in cache");
-      // But there might be scheduled a delayed removal from the local fs
-      if ((scheduledRemover = scheduledFileRemovers.get(key)) != null) {
-        LOG.log(Level.FINEST, "Exists scheduled removal for " + key
-            .getExtendedUsername());
-        // Cancel the delayed removal
-        boolean canceled = scheduledRemover.scheduledFuture.cancel(false);
-        scheduledFileRemovers.remove(key);
-        // If managed to cancel properly, just put back the reference
-        if (canceled) {
-          LOG.log(Level.FINEST, "Successfully canceled delayed removal for " +
-              key.getExtendedUsername());
-          
-          scheduledRemover.material.references++;
-          materialMap.put(key, scheduledRemover.material);
-        } else {
-          // Otherwise materialize
-          // Force deletion of material to avoid corrupted data
-          LOG.log(Level.FINEST, "Could not cancel delayed removal, " +
-              "materializing again for " + key.getExtendedUsername());
-          forceRemoveCertificates(key.username, key.projectName, false);
-          materialize(key);
-        }
-      } else {
-        // Otherwise the material has been wiped-out, so materialize it anyway
-        LOG.log(Level.FINEST, "Material for " + key.getExtendedUsername()
-            + " has been wiped out, materializing!");
-        materialize(key);
-      }
-    }
+  /*
+   * Start of Certificate materializer API
+   */
+  
+  /**
+   * Materialize project *generic* certificates in *local* filesystem in the *standard* directory
+   *
+   * @param projectName Name of the Project
+   * @throws IOException
+   */
+  public void materializeCertificatesLocal(String projectName) throws IOException {
+    materializeCertificatesLocal(null, projectName);
   }
   
-  private void materialize(MaterialKey key) throws IOException {
-    String decryptedPass;
-    // Spark/Livy and Hive in Zeppelin runs as user PROJECTNAME__PROJECTGENERICUSER and not as
-    // PROJECTNAME__USERNAME
-    if (key.isProjectUser()) {
-      ProjectGenericUserCerts projectGenericUserCerts = certsFacade.findProjectGenericUserCerts(key
-          .getExtendedUsername());
-      if (null == projectGenericUserCerts) {
-        throw new IOException("Could not find certificates for user " + key
-            .getExtendedUsername());
-      }
-      decryptedPass = decryptMaterialPassword(key.projectName,
-          projectGenericUserCerts.getCertificatePassword(),
-          ProjectGenericUserCerts.class);
-      materializeInternal(key, projectGenericUserCerts.getKey(),
-          projectGenericUserCerts.getCert(), decryptedPass);
-    } else {
-      UserCerts projectSpecificCerts = certsFacade.findUserCert(key.projectName,
-          key.username);
-      decryptedPass = decryptMaterialPassword(key
-          .getExtendedUsername(), projectSpecificCerts.getUserKeyPwd(),
-          UserCerts.class);
-      materializeInternal(key, projectSpecificCerts.getUserKey(),
-          projectSpecificCerts.getUserCert(), decryptedPass);
-    }
-  }
-  
-  private <T> String decryptMaterialPassword(String certificateIdentifier,
-      String encryptedPassword, Class<T> cls) throws IOException {
-    String userPassword;
-    if (cls == ProjectGenericUserCerts.class) {
-      // Project generic certificate
-      // Certificate identifier would be the project name
-      Project project = projectFacade.findByName(certificateIdentifier);
-      if (project == null) {
-        throw new IOException("Project with name " + certificateIdentifier +
-            " could not be found");
-      }
-      Users owner = project.getOwner();
-      userPassword = owner.getPassword();
-    } else if (cls == UserCerts.class) {
-      // Project specific certificate
-      // Certificate identifier would be the project specific username
-      String username = hdfsUsersController.getUserName(certificateIdentifier);
-      Users user = userFacade.findByUsername(username);
-      if (user == null) {
-        throw new IOException("Could not find user: " + username);
-      }
-      userPassword = user.getPassword();
-    } else {
-      throw new IllegalArgumentException("Certificate type " + cls.getName()
-          + " is unknown");
-    }
-    
+  /**
+   * Materialize project *specific* certificates in *local* filesystem in the *standard* directory
+   *
+   * @param userName Username of the user
+   * @param projectName Name of the Project
+   * @throws IOException
+   */
+  public void materializeCertificatesLocal(String userName, String projectName)
+      throws IOException {
+    MaterialKey key = new MaterialKey(userName, projectName);
     try {
-      return HopsUtils.decrypt(userPassword, encryptedPassword, certificatesMgmService.getMasterEncryptionPassword());
-    } catch (Exception ex) {
-      throw new IOException(ex);
+      localWriteLock.lock();
+      materializeLocalInternal(key, transientDir);
+    } finally {
+      localWriteLock.unlock();
     }
   }
   
-  private void materializeInternal(MaterialKey key, byte[] keyStore, byte[]
-      trustStore, String password) throws IOException {
-    if (null != keyStore && null != trustStore) {
-      flushToLocalFs(key.getExtendedUsername(), keyStore, trustStore,
-          password);
-      materialMap.put(key, new InternalCryptoMaterial(keyStore, trustStore,
-          password));
-      LOG.log(Level.FINEST, "User: " + key.getExtendedUsername() + " " +
-          "Material DOES NOT exist, flushing now!!!");
-    } else {
-      throw new IOException("Certificates for user " + key
-          .getExtendedUsername() + " could not be found in the " +
-          "database");
+  /**
+   * Materialize project *generic* certificates in *local* filesystem in a *non-standard* directory.
+   * Developer should take care of the correct permission of the directory
+   *
+   * @param projectName Name of the Project
+   * @param localDirectory Directory to materialize certificates
+   * @throws IOException
+   */
+  public void materializeCertificatesLocalCustomDir(String projectName, String localDirectory)
+    throws IOException {
+    materializeCertificatesLocalCustomDir(null, projectName, localDirectory);
+  }
+  
+  /**
+   * Materialize project *specific* certificates in *local* filesystem in a *non-standard* directory.
+   * Developer should take care of the correct permission of the directory
+   *
+   * @param userName Username of the user
+   * @param projectName Name of the Project
+   * @param localDirectory Directory to materialize certificates
+   * @throws IOException
+   */
+  public void materializeCertificatesLocalCustomDir(String userName, String projectName, String localDirectory)
+    throws IOException {
+    MaterialKey key = new MaterialKey(userName, projectName);
+    localDirectory = localDirectory != null ? localDirectory : transientDir;
+    try {
+      localWriteLock.lock();
+      materializeLocalInternal(key, localDirectory);
+    } finally {
+      localWriteLock.unlock();
     }
   }
   
-  public CryptoMaterial getUserMaterial(String projectName)
-    throws CryptoPasswordNotFoundException {
+  /**
+   * Remove project *generic* certificates from *local* filesystem, from *standard* directory
+   *
+   * @param projectName Name of the Project
+   */
+  public void removeCertificatesLocal(String projectName) {
+    removeCertificatesLocal(null, projectName);
+  }
+  
+  /**
+   * Remove project *specific* certificates from *local* filesystem, from the *standard* directory
+   *
+   * @param userName Username of the user
+   * @param projectName Name of the Project
+   */
+  public void removeCertificatesLocal(String userName, String projectName) {
+    MaterialKey key = new MaterialKey(userName, projectName);
+    try {
+      localWriteLock.lock();
+      removeLocal(key, transientDir);
+    } finally {
+      localWriteLock.unlock();
+    }
+  }
+  
+  /**
+   * Remove project *generic* certificates from *local* filesystem, from a *non-standard* directory
+   *
+   * @param projectName Name of the Project
+   * @param localDirectory Local directory where the certificates were materialized
+   */
+  public void removeCertificatesLocalCustomDir(String projectName, String localDirectory) {
+    removeCertificatesLocalCustomDir(null, projectName, localDirectory);
+  }
+  
+  /**
+   * Remove project *specific* certificates from *local* filesystem, from a *non-standard* directory
+   *
+   * @param username Username of the user
+   * @param projectName Name of the Project
+   * @param localDirectory Local directory where the certificates were materialized
+   */
+  public void removeCertificatesLocalCustomDir(String username, String projectName, String localDirectory) {
+    MaterialKey key = new MaterialKey(username, projectName);
+    localDirectory = localDirectory != null ? localDirectory : transientDir;
+    try {
+      localWriteLock.lock();
+      removeLocal(key, localDirectory);
+    } finally {
+      localWriteLock.unlock();
+    }
+  }
+  
+  /**
+   * Materialize project *specific* certificates in *remote* filesystem
+   *
+   * @param userName Username of the user
+   * @param projectName Name of the project
+   * @param ownerName Owner of remote files
+   * @param groupName Group of remote files
+   * @param permissions Permissions of remote files
+   * @param remoteDirectory Remote directory to put the material
+   * @throws IOException
+   */
+  public void materializeCertificatesRemote(String userName, String projectName, String ownerName, String groupName,
+      FsPermission permissions, String remoteDirectory) throws IOException {
+    if (remoteDirectory == null) {
+      throw new IllegalArgumentException("Remote directory should not be null");
+    }
+    remoteDirectory = normalizeURI(remoteDirectory);
+    MaterialKey key = new MaterialKey(userName, projectName);
+    try {
+      remoteWriteLock.lock();
+      materializeRemoteInternal(key, ownerName, groupName, permissions, remoteDirectory);
+    } finally {
+      remoteWriteLock.unlock();
+    }
+  }
+  
+  /**
+   * Remote project *specific* certificates from *remote* filesystem
+   *
+   * @param userName Username of the user
+   * @param projectName Name of the Project
+   * @param remoteDirectory Remote directory the material was put to
+   */
+  public void removeCertificatesRemote(String userName, String projectName, String remoteDirectory) {
+    if (remoteDirectory == null) {
+      throw new IllegalArgumentException("Remote directory cannot be null");
+    }
+    remoteDirectory = normalizeURI(remoteDirectory);
+    MaterialKey key = new MaterialKey(userName, projectName);
+    try {
+      remoteWriteLock.lock();
+      removeRemoteInternal(key, remoteDirectory, false);
+    } finally {
+      remoteWriteLock.unlock();
+    }
+  }
+  
+  /**
+   * Forcefully remove crypto material from *remote* filesystem regardless the references
+   *
+   * CAUTION: Other applications or Hopsworks instances might be still using them
+   *
+   * @param username Username of the user
+   * @param projectName Name of the Project
+   * @param remoteDirectory Remote directory the material was put to
+   * @param bothProjectAndUser Remove both project specific and project generic material
+   */
+  public void forceRemoveRemoteMaterial(String username, String projectName, String remoteDirectory,
+      boolean bothProjectAndUser) {
+    if (remoteDirectory == null) {
+      throw new IllegalArgumentException("Remote directory cannot be null");
+    }
+    remoteDirectory = normalizeURI(remoteDirectory);
+    try {
+      remoteWriteLock.lock();
+      MaterialKey key = new MaterialKey(username, projectName);
+      removeRemoteInternal(key, remoteDirectory, true);
+      if (bothProjectAndUser) {
+        key = new MaterialKey(null, projectName);
+        removeRemoteInternal(key, remoteDirectory, true);
+      }
+    } finally {
+      remoteWriteLock.unlock();
+    }
+  }
+  
+  /**
+   * Get reference to project *generic* material. The certificates should have already been materialized
+   *
+   * @param projectName Name of the project
+   * @return Reference to crypto material
+   * @throws CryptoPasswordNotFoundException In case the material was not found in local store
+   */
+  public CryptoMaterial getUserMaterial(String projectName) throws CryptoPasswordNotFoundException {
     return getUserMaterial(null, projectName);
   }
   
-  @Lock(LockType.READ)
-  public CryptoMaterial getUserMaterial(String username, String projectName)
-    throws CryptoPasswordNotFoundException {
+  /**
+   * Get reference to project *specific* material. The certificates should have already been materialized
+   *
+   * @param username Username of the user
+   * @param projectName Name of the project
+   * @return Reference to crypto material
+   * @throws CryptoPasswordNotFoundException In case the material was not found in local store
+   */
+  public CryptoMaterial getUserMaterial(String username, String projectName) throws CryptoPasswordNotFoundException {
     MaterialKey key = new MaterialKey(username, projectName);
-    InternalCryptoMaterial material = materialMap.get(key);
-    if (null != material) {
-      return new CryptoMaterial(material.getKeyStore(), material
-          .getTrustStore(), material.getPassword());
-    }
-    
-    throw new CryptoPasswordNotFoundException(
-        "Cryptographic material for user " + key.getExtendedUsername() +
-            " does not exist!");
-  }
-  
-  public void removeCertificate(String projectName) {
-    removeCertificate(null, projectName);
-  }
-  
-  @Lock(LockType.WRITE)
-  @AccessTimeout(value=100)
-  public void removeCertificate(String username, String projectName) {
-    MaterialKey key = new MaterialKey(username, projectName);
-    InternalCryptoMaterial material = materialMap.get(key);
-    if (null != material) {
-      LOG.log(Level.FINEST, "Requested removal of material for " + key
-          .getExtendedUsername() + " Ref: " + material.references);
-    }
-    if (null != material && material.decrementReference()) {
-      materialMap.remove(key);
-      scheduleFileRemover(key, new FileRemover(key, material));
-    }
-  }
-  
-  @Lock(LockType.WRITE)
-  @AccessTimeout(value=100)
-  public void forceRemoveCertificates(String username, String projectName,
-      boolean bothUserAndProject) {
-    // Remove project specific certificates, if any
-    MaterialKey key = new MaterialKey(username, projectName);
-    FileRemover scheduledRemover = scheduledFileRemovers.remove(key);
-    if (null != scheduledRemover) {
-      scheduledRemover.scheduledFuture.cancel(true);
-    }
-    deleteMaterialFromLocalFs(key.getExtendedUsername());
-    materialMap.remove(key);
-    
-    if (bothUserAndProject) {
-      // Remove project generic certificates, if any
-      key = new MaterialKey(null, projectName);
-      scheduledRemover = scheduledFileRemovers.remove(key);
-      if (null != scheduledRemover) {
-        scheduledRemover.scheduledFuture.cancel(true);
+    try {
+      localReadLock.lock();
+      CryptoMaterial material = materialCache.get(key);
+      if (material == null) {
+        throw new CryptoPasswordNotFoundException("Cryptographic material for user <" + key.getExtendedUsername() + "" +
+            " does not exist in the cache!");
       }
-      deleteMaterialFromLocalFs(key.getExtendedUsername());
-      materialMap.remove(key);
+      return material;
+    } finally {
+      localReadLock.unlock();
     }
   }
   
-  @Lock(LockType.READ)
-  @AccessTimeout(value=200)
-  public boolean existsInStore(String username, String projectName) {
+  /**
+   * Forcefully remove crypto material from *local* filesystem regardless the references
+   *
+   * CAUTION: Other applications might be still using them
+   *
+   * @param username Username of the user
+   * @param projectName Name of the Project
+   * @param materializationDirectory Local directory the material was put to
+   * @param bothProjectAndUser Remove both project specific and project generic material
+   */
+  public void forceRemoveLocalMaterial(String username, String projectName, String materializationDirectory,
+      boolean bothProjectAndUser) {
+    forceRemoveLocalMaterial(username, projectName, materializationDirectory);
+    if (bothProjectAndUser) {
+      forceRemoveLocalMaterial(null, projectName, materializationDirectory);
+    }
+  }
+  
+  /**
+   * Check if certificates have been materialized in the *local* filesystem in the directory specified
+   *
+   * @param username Username of the user
+   * @param projectName Name of the project
+   * @param directory Directory to check if the certificates have been materialized
+   * @return True if the material exists in the cache, otherwise false
+   */
+  public boolean existsInLocalStore(String username, String projectName, String directory) {
+    directory = directory != null ? directory : transientDir;
     MaterialKey key = new MaterialKey(username, projectName);
-    return materialMap.containsKey(key);
+    try {
+      localReadLock.lock();
+      Bag materializedPaths = materializedCerts.get(key);
+      if (materializedPaths == null) {
+        return false;
+      }
+      
+      return materializedPaths.contains(directory);
+    } finally {
+      localReadLock.unlock();
+    }
   }
   
-  private void scheduleFileRemover(MaterialKey key, FileRemover fileRemover) {
-    fileRemover.scheduledFuture = scheduler.schedule(fileRemover, DELAY_VALUE,
-        DELAY_TIMEUNIT);
+  /**
+   * Check if certificates have been materialized in the *remote* filesystem in the directory specified
+   *
+   * @param username Username of the user
+   * @param projectName Name of the project
+   * @param remoteDirectory Directory to check if the certificates have been materialized
+   * @return True if the material exists in the cache, otherwise false
+   */
+  public boolean existsInRemoteStore(String username, String projectName, String remoteDirectory) {
+    if (remoteDirectory == null) {
+      throw new IllegalArgumentException("Remote directory cannot be null");
+    }
+    MaterialKey key = new MaterialKey(username, projectName);
+    RemoteMaterialRefID identifier = new RemoteMaterialRefID(key.getExtendedUsername(), remoteDirectory);
+    RemoteMaterialReferences ref = remoteMaterialReferencesFacade.findById(identifier);
     
-    scheduledFileRemovers.put(key, fileRemover);
-    LOG.log(Level.FINEST, "Scheduled removal of material for " + key.getExtendedUsername());
+    return ref != null;
   }
   
+  /*
+   * End of Certificate materializer API
+   */
+  
+  
+  /*
+   * This section provides methods for monitoring and control
+   */
+  
+  /**
+   * Returns the state of the CertificateMaterializer service
+   * The state includes:
+   * 1) Identifier of material, materialization directory and number of references for the certificates in the local
+   * filesystem
+   *
+   * 2) Identifier of material, materialization directory and number of references for the certificates in the remote
+   * filesystem (HDFS)
+   *
+   * 3) Identifier of the material that are scheduled to be removed from the local filesystem
+   *
+   * @return The state of the CertificateMaterializer at that point of time
+   */
+  @SuppressWarnings("unchecked")
+  public MaterializerState<Map<String, Map<String, Integer>>, Map<String, Map<String, Integer>>,
+      Map<String, Set<String>>> getState() {
+    MaterializerState<Map<MaterialKey, Bag>, List<RemoteMaterialReferences>, Map<MaterialKey, Map<String, Runnable>>>
+        state = getImmutableState();
+    
+    Map<MaterialKey, Bag> localMaterialState = state.getLocalMaterial();
+    
+    // <Username, <MaterialPath, NumberOfReferences>>
+    Map<String, Map<String, Integer>> simpleLocalMaterialState = new HashMap<>(localMaterialState.size());
+    
+    for (Map.Entry<MaterialKey, Bag> entry : localMaterialState.entrySet()) {
+      String username = entry.getKey().getExtendedUsername();
+      Map<String, Integer> referencesMap = new HashMap<>();
+      Bag pathsBag = entry.getValue();
+      Set<String> paths = pathsBag.uniqueSet();
+      for (String path : paths) {
+        referencesMap.put(path, pathsBag.getCount(path));
+      }
+      simpleLocalMaterialState.put(username, referencesMap);
+    }
+    
+    List<RemoteMaterialReferences> remoteMaterialState = state.getRemoteMaterial();
+    // <Username, <MaterialPath, NumberOfReferences>>
+    Map<String, Map<String, Integer>> simpleRemoteMaterialState = new HashMap<>(remoteMaterialState.size());
+    
+    for (RemoteMaterialReferences ref : remoteMaterialState) {
+      String username = ref.getIdentifier().getUsername();
+      Map<String, Integer> references = simpleRemoteMaterialState.get(username);
+      if (references == null) {
+        references = new HashMap<>();
+        references.put(ref.getIdentifier().getPath(), ref.getReferences());
+        simpleRemoteMaterialState.put(username, references);
+      } else {
+        references.put(ref.getIdentifier().getPath(), ref.getReferences());
+      }
+    }
+    
+    Map<MaterialKey, Map<String, Runnable>> fileRemovals = state.getScheduledRemovals();
+    // <Username, [MaterialPath]>
+    Map<String, Set<String>> simpleScheduledRemovals = new HashMap<>();
+    
+    for (Map.Entry<MaterialKey, Map<String, Runnable>> entry : fileRemovals.entrySet()) {
+      String username = entry.getKey().getExtendedUsername();
+      simpleScheduledRemovals.put(username, entry.getValue().keySet());
+    }
+    
+    return new MaterializerState<>(simpleLocalMaterialState, simpleRemoteMaterialState, simpleScheduledRemovals);
+  }
+  
+  private MaterializerState<Map<MaterialKey, Bag>, List<RemoteMaterialReferences>,
+      Map<MaterialKey, Map<String, Runnable>>> getImmutableState() {
+    Map<MaterialKey, Bag> localMaterial = null;
+    Map<MaterialKey, Map<String, Runnable>> scheduledRemovals = null;
+    List<RemoteMaterialReferences> remoteMaterial = null;
+    try {
+      localWriteLock.lock();
+      localMaterial = MapUtils.unmodifiableMap(materializedCerts);
+      scheduledRemovals = MapUtils.unmodifiableMap(fileRemovers);
+    } finally {
+      localWriteLock.unlock();
+    }
+    
+    try {
+      remoteWriteLock.lock();
+      remoteMaterial = remoteMaterialReferencesFacade.findAll();
+    } finally {
+      remoteWriteLock.unlock();
+    }
+    
+    return new MaterializerState(localMaterial, remoteMaterial, scheduledRemovals);
+  }
+  
+  
+  public class MaterializerState<T, S, R> {
+    private final T localMaterial;
+    private final S remoteMaterial;
+    private final R scheduledRemovals;
+    
+    public MaterializerState(T localMaterial, S remoteMaterial, R scheduledRemovals) {
+      this.localMaterial = localMaterial;
+      this.remoteMaterial = remoteMaterial;
+      this.scheduledRemovals = scheduledRemovals;
+    }
+    
+    public T getLocalMaterial() {
+      return localMaterial;
+    }
+    
+    public S getRemoteMaterial() {
+      return remoteMaterial;
+    }
+    
+    public R getScheduledRemovals() {
+      return scheduledRemovals;
+    }
+  }
+  
+  
+  /*
+   * Methods to keep track of open interpreters and when to materialize certificates
+   */
   /**
    * It is called every time a paragraph is executed in Zeppelin. If the certificates for a Project has already been
    * materialized, this method will return false and they will not be materialized again.
@@ -430,50 +674,497 @@ public class CertificateMaterializer {
     projectsWithOpenInterpreters.remove(projectId);
   }
   
-  private void deleteMaterialFromLocalFs(String username) {
-    File kstoreFile = Paths.get(transientDir, username
-        + "__kstore.jks").toFile();
-    File tstoreFile = Paths.get(transientDir, username
-        + "__tstore.jks").toFile();
-    File certPassFile = Paths.get(transientDir, username
-        + CERT_PASS_SUFFIX).toFile();
-    FileUtils.deleteQuietly(kstoreFile);
-    FileUtils.deleteQuietly(tstoreFile);
-    FileUtils.deleteQuietly(certPassFile);
-  }
-  
-  private void flushToLocalFs(String username, byte[] kstore, byte[] tstore,
-      String password) throws IOException {
-    File kstoreFile = Paths.get(transientDir, username + "__kstore.jks")
-        .toFile();
-    File tstoreFile = Paths.get(transientDir, username + "__tstore.jks")
-        .toFile();
-    File certPassFile = Paths.get(transientDir, username + CERT_PASS_SUFFIX)
-        .toFile();
-  
-    FileUtils.writeByteArrayToFile(kstoreFile, kstore, false);
-    FileUtils.writeByteArrayToFile(tstoreFile, tstore, false);
-    FileUtils.writeStringToFile(certPassFile, password, false);
-  }
-  
-  private class FileRemover implements Runnable {
-    private final MaterialKey key;
-    private final InternalCryptoMaterial material;
-    private ScheduledFuture scheduledFuture;
+  /*
+   * Materialize local section
+   */
+  private void materializeLocalInternal(MaterialKey key, String localDirectory) throws IOException {
+    Bag materializedDirs = materializedCerts.get(key);
+    if (materializedDirs == null) {
+      // Check to see if there is any scheduled removal
+      // If there is try to cancel it
+      // If not possible materialize
     
-    private FileRemover(MaterialKey key, InternalCryptoMaterial material) {
-      this.key = key;
-      this.material = material;
+      boolean shouldContinue = checkWithScheduledRemovalsLocal(key, localDirectory);
+      if (shouldContinue) {
+        // First time it was requested to be materialized
+        // 1. Get certs fro DB
+        CryptoMaterial material = getMaterialFromDatabase(key);
+        // 2. Add them to L1 Cache
+        materialCache.put(key, material);
+        // 3. Write them to local FS
+        flushToLocalFileSystem(key, material, localDirectory);
+        // 4. Add Directory to Bag and then to materializedCerts
+        Bag materialBag = new HashBag();
+        String targetDir = localDirectory != null ? localDirectory : transientDir;
+        materialBag.add(targetDir, 1);
+        materializedCerts.put(key, materialBag);
+      }
+    } else {
+      int cardinality = materializedDirs.getCount(localDirectory);
+      if (cardinality == 0) {
+        // Check to see if there is any scheduled removal
+        // If there is try to cancel it
+        // If not possible materialize
+        boolean shouldContinue = checkWithScheduledRemovalsLocal(key, localDirectory);
+      
+        if (shouldContinue) {
+          // First time for this directory, but not for the material in general
+          // 1. Get byte material from L1 Cache. If not there, something went wrong
+          // but fetch them from DB anyways
+          CryptoMaterial material = materialCache.get(key);
+          if (material == null) {
+            material = getMaterialFromDatabase(key);
+          }
+          // 2. Flush buffers to local filesystem
+          flushToLocalFileSystem(key, material, localDirectory);
+          // 3. Increment cardinality
+          materializedDirs.add(localDirectory, 1);
+        }
+      } else {
+        // Materialization in this Directory has already been requested
+        // 1. Increment cardinality for this Material and Directory
+        materializedDirs.add(localDirectory, 1);
+      }
+    }
+  }
+  
+  // Return true if materializeCertificates should proceed with the materialization
+  private boolean checkWithScheduledRemovalsLocal(MaterialKey key, String materializationDirectory)
+      throws IOException {
+    Map<String, Runnable> materialRemovers = fileRemovers.get(key);
+    if (materialRemovers == null) {
+      return true;
     }
     
-    @Override
-    public void run() {
-      deleteMaterialFromLocalFs(key.getExtendedUsername());
-      scheduledFileRemovers.remove(key);
-      LOG.log(Level.FINEST, "Wiped out material for " + key.getExtendedUsername());
+    LocalFileRemover localFileRemover = (LocalFileRemover) materialRemovers.get(materializationDirectory);
+    if (localFileRemover == null) {
+      return true;
+    }
+    
+    boolean managedToCancel = localFileRemover.scheduledFuture.cancel(false);
+    if (managedToCancel) {
+      // Put back to L1 cache
+      if (!materialCache.containsKey(key)) {
+        if (localFileRemover.cryptoMaterial != null) {
+          materialCache.put(key, localFileRemover.cryptoMaterial);
+        } else {
+          CryptoMaterial material = getMaterialFromDatabase(key);
+          materialCache.put(key, material);
+        }
+      }
+      // Put back to material map
+      Bag materializeBag = materializedCerts.get(key);
+      if (materializeBag != null) {
+        materializeBag.add(materializationDirectory, 1);
+      } else {
+        Bag materializedBag = new HashBag();
+        materializedBag.add(materializationDirectory);
+        materializedCerts.put(key, materializedBag);
+      }
+  
+      // Remove from scheduled removers
+      materialRemovers.remove(materializationDirectory);
+      if (materialRemovers.isEmpty()) {
+        fileRemovers.remove(key);
+      }
+      return false;
+    } else {
+      forceRemoveLocalMaterial(key.username, key.projectName, materializationDirectory);
+      return true;
     }
   }
-
+  
+  private void flushToLocalFileSystem(MaterialKey key, CryptoMaterial cryptoMaterial, String materializationDirectory)
+      throws IOException {
+    String targetDir = materializationDirectory != null ? materializationDirectory : transientDir;
+    File keyStoreFile = Paths.get(targetDir, key.getExtendedUsername() + KEYSTORE_SUFFIX).toFile();
+    File trustStoreFile = Paths.get(targetDir, key.getExtendedUsername() + TRUSTSTORE_SUFFIX).toFile();
+    File passwordFile = Paths.get(targetDir, key.getExtendedUsername() + CERT_PASS_SUFFIX).toFile();
+    
+    FileUtils.writeByteArrayToFile(keyStoreFile, cryptoMaterial.getKeyStore().array(), false);
+    FileUtils.writeByteArrayToFile(trustStoreFile, cryptoMaterial.getTrustStore().array(), false);
+    FileUtils.write(passwordFile, new String(cryptoMaterial.getPassword()), false);
+  }
+  
+  
+  
+  /*
+   * Remove local section
+   */
+  private void removeLocal(MaterialKey key, String materializationDirectory) {
+    Bag materialBag = materializedCerts.get(key);
+    if (materialBag != null) {
+      materialBag.remove(materializationDirectory, 1);
+      if (materialBag.getCount(materializationDirectory) <= 0) {
+        scheduleFileRemover(key, materializationDirectory);
+      }
+      
+      // No more references to that crypto material
+      if (materialBag.isEmpty()) {
+        materializedCerts.remove(key);
+        CryptoMaterial material = materialCache.remove(key);
+        if (material != null) {
+          material.wipePassword();
+        }
+      }
+    }
+  }
+  
+  private void scheduleFileRemover(MaterialKey key, String materializationDirectory) {
+    LocalFileRemover fileRemover = new LocalFileRemover(key, materialCache.get(key), materializationDirectory);
+    fileRemover.scheduledFuture = scheduler.schedule(fileRemover, DELAY_VALUE, DELAY_TIMEUNIT);
+    
+    Map<String, Runnable> materialRemovesForKey = fileRemovers.get(key);
+    if (materialRemovesForKey != null) {
+      materialRemovesForKey.put(materializationDirectory, fileRemover);
+    } else {
+      materialRemovesForKey = new HashMap<>();
+      materialRemovesForKey.put(materializationDirectory, fileRemover);
+      fileRemovers.put(key, materialRemovesForKey);
+    }
+    
+    LOG.log(Level.FINEST, "Scheduled local file removal for <" + key.getExtendedUsername() + ">");
+  }
+  
+  private void deleteMaterialFromLocalFs(MaterialKey key, String materializationDirectory) {
+    File keyStoreFile = Paths.get(materializationDirectory, key.getExtendedUsername() + KEYSTORE_SUFFIX)
+        .toFile();
+    File trustStoreFile = Paths.get(materializationDirectory, key.getExtendedUsername() + TRUSTSTORE_SUFFIX)
+        .toFile();
+    File passwordFile = Paths.get(materializationDirectory, key.getExtendedUsername() + CERT_PASS_SUFFIX)
+        .toFile();
+    FileUtils.deleteQuietly(keyStoreFile);
+    FileUtils.deleteQuietly(trustStoreFile);
+    FileUtils.deleteQuietly(passwordFile);
+  }
+  
+  private void forceRemoveLocalMaterial(String username, String projectName, String materializationDirectory) {
+    try {
+      localWriteLock.lock();
+      materializationDirectory = materializationDirectory != null ? materializationDirectory : transientDir;
+      MaterialKey key = new MaterialKey(username, projectName);
+      // First remove from File Removers list
+      Map<String, Runnable> materialRemovers = fileRemovers.get(key);
+      if (materialRemovers != null) {
+        LocalFileRemover fileRemover = (LocalFileRemover) materialRemovers.remove(materializationDirectory);
+        if (fileRemover != null) {
+          fileRemover.scheduledFuture.cancel(true);
+        }
+        if (materialRemovers.isEmpty()) {
+          fileRemovers.remove(key);
+        }
+      }
+      
+      // Then remove from material Map and maybe from Cache
+      Bag materialBag = materializedCerts.get(key);
+      if (materialBag != null) {
+        materialBag.remove(materializationDirectory);
+        if (materialBag.isEmpty()) {
+          materializedCerts.remove(key);
+          CryptoMaterial material = materialCache.remove(key);
+          if (material != null) {
+            material.wipePassword();
+          }
+        }
+      }
+      
+      // Then from local FS
+      deleteMaterialFromLocalFs(key, materializationDirectory);
+    } finally {
+      localWriteLock.unlock();
+    }
+  }
+  
+  
+  /*
+   * Materialize remote section
+   */
+  private void materializeRemoteInternal(MaterialKey key, String ownerName, String groupName,
+      FsPermission permissions, String remoteDirectory) throws IOException {
+    
+    RemoteMaterialReferences materialRef = null;
+    RemoteMaterialRefID identifier = new RemoteMaterialRefID(key.getExtendedUsername(), remoteDirectory);
+    
+    int retries = 0;
+    while (materialRef == null && retries < MAX_NUMBER_OF_RETRIES) {
+      try {
+        materialRef = remoteMaterialReferencesFacade.acquireLock(identifier, lock_id);
+        
+        // Managed to take the lock, proceed
+        if (materialRef == null) {
+          remoteMaterialReferencesFacade.createNewMaterialReference(identifier);
+          materialRef = remoteMaterialReferencesFacade.acquireLock(identifier, lock_id);
+          // First time request for this material in this directory
+          // 1. Check if in cache otherwise fetch from DB
+          CryptoMaterial material = materialCache.get(key);
+          if (material == null) {
+            material = getMaterialFromDatabase(key);
+          }
+          
+          // 2. Upload to HDFS
+          DistributedFileSystemOps dfso = distributedFsService.getDfsOps();
+          try {
+            Path keyStore = new Path(remoteDirectory + Path.SEPARATOR + key.getExtendedUsername()
+                + KEYSTORE_SUFFIX);
+            writeToHDFS(dfso, keyStore, material.getKeyStore().array());
+            dfso.setOwner(keyStore, ownerName, groupName);
+            dfso.setPermission(keyStore, permissions);
+            
+            Path trustStore = new Path(remoteDirectory + Path.SEPARATOR + key.getExtendedUsername()
+                + TRUSTSTORE_SUFFIX);
+            writeToHDFS(dfso, trustStore, material.getKeyStore().array());
+            dfso.setOwner(trustStore, ownerName, groupName);
+            dfso.setPermission(trustStore, permissions);
+            
+            // If RPC TLS is enabled, password file is injected automatically by the NodeManager
+            if (!settings.getHopsRpcTls()) {
+              Path passwordFile = new Path(remoteDirectory + Path.SEPARATOR + key.getExtendedUsername()
+                  + CERT_PASS_SUFFIX);
+              writeToHDFS(dfso, passwordFile, new String(material.getPassword()));
+              dfso.setOwner(passwordFile, ownerName, groupName);
+              dfso.setPermission(passwordFile, permissions);
+            }
+            
+            // Cache should be flushed otherwise NN will raise permission exceptions
+            dfso.flushCache(ownerName, groupName);
+          } finally {
+            if (dfso != null) {
+              distributedFsService.closeDfsClient(dfso);
+            }
+          }
+          
+          // 3. Set the correct initial references and persist
+          materialRef.setReferences(1);
+          remoteMaterialReferencesFacade.update(materialRef);
+        } else {
+          materialRef.incrementReferences();
+          remoteMaterialReferencesFacade.update(materialRef);
+        }
+      } catch (Exception ex) {
+        if (ex instanceof AcquireLockException) {
+          LOG.log(Level.WARNING, ex.getMessage(), ex);
+          retries++;
+          try {
+            TimeUnit.MILLISECONDS.sleep(RETRY_WAIT_TIMEOUT);
+          } catch (InterruptedException iex) {
+            throw new IOException(iex);
+          }
+        } else {
+          throw new IOException(ex);
+        }
+      } finally {
+        try {
+          remoteMaterialReferencesFacade.releaseLock(identifier, lock_id);
+        } catch (AcquireLockException ex) {
+          LOG.log(Level.SEVERE, "Cannot release lock for " + identifier, ex);
+        }
+      }
+    }
+    
+    if (materialRef == null) {
+      throw new IOException("Could not materialize certificates for " + key.getExtendedUsername()
+          + " in remote directory " + remoteDirectory);
+    }
+  }
+  
+  
+  private void writeToHDFS(DistributedFileSystemOps dfso, Path path, byte[] data) throws IOException {
+    if (dfso == null) {
+      throw new IOException("DistributedFilesystemOps is null");
+    }
+    FSDataOutputStream fsStream = dfso.getFilesystem().create(path);
+    try {
+      fsStream.write(data);
+      fsStream.hflush();
+    } finally {
+      if (fsStream != null) {
+        fsStream.close();
+      }
+    }
+  }
+  
+  private void writeToHDFS(DistributedFileSystemOps dfso, Path path, String data) throws IOException {
+    if (dfso == null) {
+      throw new IOException("DistributedFilesystemOps is null");
+    }
+    FSDataOutputStream fsStream = dfso.getFilesystem().create(path);
+    try {
+      fsStream.writeUTF(data);
+      fsStream.hflush();
+    } finally {
+      if (fsStream != null) {
+        fsStream.close();
+      }
+    }
+  }
+  
+  /*
+   * Remove remote section
+   */
+  
+  private void removeRemoteInternal(MaterialKey key, String remoteDirectory, boolean force) {
+    RemoteMaterialReferences materialRef = null;
+    RemoteMaterialRefID identifier = new RemoteMaterialRefID(key.getExtendedUsername(), remoteDirectory);
+    
+    int retries = 0;
+    while (materialRef == null && retries < MAX_NUMBER_OF_RETRIES) {
+      try {
+        materialRef = remoteMaterialReferencesFacade.acquireLock(identifier, lock_id);
+        
+        if (materialRef != null) {
+          materialRef.decrementReferences();
+          
+          if (materialRef.getReferences() <= 0 || force) {
+            DistributedFileSystemOps dfso = distributedFsService.getDfsOps();
+            try {
+              dfso.rm(new Path(remoteDirectory), true);
+            } catch (IOException ex) {
+              LOG.log(Level.SEVERE, "Crypto material for <" + key.getExtendedUsername()
+                  + "> could not be removed from HDFS. You SHOULD clean them manually!");
+            }
+            remoteMaterialReferencesFacade.delete(materialRef.getIdentifier());
+          } else {
+            materialRef.decrementReferences();
+            remoteMaterialReferencesFacade.update(materialRef);
+          }
+        } else {
+          LOG.log(Level.WARNING, "Could not find remote crypto material for " + key.getExtendedUsername() + " to " +
+              "remove");
+          break;
+        }
+      } catch (Exception ex) {
+        if (ex instanceof AcquireLockException) {
+          LOG.log(Level.WARNING, ex.getMessage(), ex);
+          retries++;
+          try {
+            TimeUnit.MILLISECONDS.sleep(RETRY_WAIT_TIMEOUT);
+          } catch (InterruptedException iex) {
+            throw new IllegalStateException(iex);
+          }
+        } else {
+          throw new RuntimeException(ex);
+        }
+      } finally {
+        try {
+          remoteMaterialReferencesFacade.releaseLock(identifier, lock_id);
+        } catch (AcquireLockException ex) {
+          LOG.log(Level.SEVERE, "Cannot release lock for " + identifier, ex);
+        }
+      }
+    }
+  }
+  
+  private String normalizeURI(String uri) {
+    Matcher uriMatcher = HDFS_SCHEME.matcher(uri);
+    if (!uriMatcher.matches()) {
+      uri = "hdfs://" + uri;
+    }
+    return uri;
+  }
+  
+  private void deleteFromHDFS(DistributedFileSystemOps dfso, Path path) throws IOException {
+    dfso.rm(path, false);
+  }
+  
+  
+  /*
+   * Utility methods
+   */
+  private CryptoMaterial getMaterialFromDatabase(MaterialKey key) throws IOException {
+    if (key.isProjectUser()) {
+      ProjectGenericUserCerts projectGenericUserCerts = certsFacade.findProjectGenericUserCerts(key
+          .getExtendedUsername());
+      if (projectGenericUserCerts == null) {
+        String msg = "Could not find certificates in the database for user <" + key.getExtendedUsername() + ">";
+        LOG.log(Level.SEVERE, msg);
+        throw new IOException(msg);
+      }
+      ByteBuffer keyStore = ByteBuffer.wrap(projectGenericUserCerts.getKey());
+      ByteBuffer trustStore = ByteBuffer.wrap(projectGenericUserCerts.getCert());
+      char[] password = decryptMaterialPassword(key.projectName, projectGenericUserCerts
+          .getCertificatePassword(), ProjectGenericUserCerts.class);
+      return new CryptoMaterial(keyStore, trustStore, password);
+    }
+  
+    UserCerts projectSpecificCerts = certsFacade.findUserCert(key.projectName, key.username);
+    ByteBuffer keyStore = ByteBuffer.wrap(projectSpecificCerts.getUserKey());
+    ByteBuffer trustStore = ByteBuffer.wrap(projectSpecificCerts.getUserCert());
+    char[] password = decryptMaterialPassword(key.getExtendedUsername(), projectSpecificCerts.getUserKeyPwd(),
+        UserCerts.class);
+    return new CryptoMaterial(keyStore, trustStore, password);
+  }
+  
+  private <T> char[] decryptMaterialPassword(String certificateIdentifier, String encryptedPassword, Class<T> cls)
+      throws IOException {
+    String userPassword;
+    if (ProjectGenericUserCerts.class == cls) {
+      // Project generic certificates
+      // Certificate Identifier will be the name of the Project
+      Project project = projectFacade.findByName(certificateIdentifier);
+      if (project == null) {
+        String msg = "Project <" + certificateIdentifier + "> could not be found in the system";
+        LOG.log(Level.SEVERE, msg);
+        throw new IOException(msg);
+      }
+      Users owner = project.getOwner();
+      userPassword = owner.getPassword();
+    } else if (UserCerts.class == cls) {
+      // Project specific certificates
+      // Certificates Identifier will be the project specific username
+      String username = hdfsUsersController.getUserName(certificateIdentifier);
+      Users user = userFacade.findByUsername(username);
+      if (user == null) {
+        String msg = "Could not find user <" + certificateIdentifier + "> in the system";
+        LOG.log(Level.SEVERE, msg);
+        throw new IOException(msg);
+      }
+      userPassword = user.getPassword();
+    } else {
+      String msg = "Unknown certificate type: " + cls.getName();
+      LOG.log(Level.SEVERE, msg);
+      throw new IllegalArgumentException(msg);
+    }
+    try {
+      String decryptedPassword = HopsUtils.decrypt(userPassword, encryptedPassword, certificatesMgmService
+          .getMasterEncryptionPassword());
+      return decryptedPassword.toCharArray();
+    } catch (Exception ex) {
+      LOG.log(Level.SEVERE, "Error while decrypting certificate password for user <" + certificateIdentifier + ">");
+      throw new IOException(ex);
+    }
+  }
+  
+  
+  public class CryptoMaterial {
+    private final ByteBuffer keyStore;
+    private final ByteBuffer trustStore;
+    private final char[] password;
+    
+    public CryptoMaterial(ByteBuffer keyStore, ByteBuffer trustStore, char[] password) {
+      this.keyStore = keyStore;
+      this.trustStore = trustStore;
+      this.password = password;
+    }
+  
+    public ByteBuffer getKeyStore() {
+      return keyStore;
+    }
+  
+    public ByteBuffer getTrustStore() {
+      return trustStore;
+    }
+  
+    public char[] getPassword() {
+      return password;
+    }
+    
+    public void wipePassword() {
+      for (int i = 0; i < password.length; i++) {
+        password[i] = 0;
+      }
+    }
+  }
+  
   private class MaterialKey {
     private final String username;
     private final String projectName;
@@ -481,16 +1172,12 @@ public class CertificateMaterializer {
     
     private MaterialKey(String username, String projectName) {
       this.username = username;
-
       if (username == null) {
-        // Project Generic User certificate
         this.isProjectUser = true;
-        this.projectName = projectName;
       } else {
-        // Project Specific User certificate
         this.isProjectUser = false;
-        this.projectName = projectName;
       }
+      this.projectName = projectName;
     }
     
     private boolean isProjectUser() {
@@ -501,27 +1188,26 @@ public class CertificateMaterializer {
       if (isProjectUser) {
         return projectName + Settings.PROJECT_GENERIC_USER_SUFFIX;
       }
-
       return projectName + HdfsUsersController.USER_NAME_DELIMITER + username;
     }
-    
+  
     @Override
     public boolean equals(Object other) {
       if (this == other) {
         return true;
       }
-      
-      if (other instanceof MaterialKey) {
-        if (null != this.username && null != ((MaterialKey) other).username) {
-          return this.username.equals(((MaterialKey) other).username)
-              && this.projectName.equals(((MaterialKey) other).projectName);
+    
+      if (other instanceof CertificateMaterializer.MaterialKey) {
+        if (null != this.username && null != ((CertificateMaterializer.MaterialKey) other).username) {
+          return this.username.equals(((CertificateMaterializer.MaterialKey) other).username)
+              && this.projectName.equals(((CertificateMaterializer.MaterialKey) other).projectName);
         }
-        return this.projectName.equals(((MaterialKey) other).projectName);
+        return this.projectName.equals(((CertificateMaterializer.MaterialKey) other).projectName);
       }
-      
+    
       return false;
     }
-    
+  
     @Override
     public int hashCode() {
       int result = 17;
@@ -533,100 +1219,30 @@ public class CertificateMaterializer {
     }
   }
   
-  public class CryptoMaterial {
-    private final byte[] keyStore;
-    private final byte[] trustStore;
-    private final String password;
+  private class LocalFileRemover implements Runnable {
+    private final MaterialKey key;
+    private final CryptoMaterial cryptoMaterial;
+    private final String materializationDirectory;
+    private ScheduledFuture scheduledFuture;
     
-    public CryptoMaterial(byte[] keyStore, byte[] trustStore, String password) {
-      this.keyStore = keyStore;
-      this.trustStore = trustStore;
-      this.password = password;
+    private LocalFileRemover(MaterialKey key, CryptoMaterial cryptoMaterial, String materializationDirectory) {
+      this.key = key;
+      this.cryptoMaterial = cryptoMaterial;
+      this.materializationDirectory = materializationDirectory != null ? materializationDirectory : transientDir;
     }
     
-    public byte[] getKeyStore() {
-      return keyStore;
-    }
-    
-    public byte[] getTrustStore() {
-      return trustStore;
-    }
-    
-    public String getPassword() {
-      return password;
-    }
-  }
-  
-  private class InternalCryptoMaterial extends CryptoMaterial {
-    private int references;
-    
-    private InternalCryptoMaterial(byte[] keystore, byte[] trustStore,
-        String password) {
-      super(keystore, trustStore, password);
-      references = 1;
-    }
-    
-    private boolean decrementReference() {
-      return --references == 0;
-    }
-    
-    private void incrementReference() {
-      references++;
-    }
-  }
-  
-  /**
-   * This section provides methods for monitoring and control.
-   */
-  
-  /**
-   * Return an immutable state of the CertificateMaterializer service. Both the materialized and those scheduled for
-   * removal
-   * @return Immutable state of CertificateMaterializer service
-   */
-  @SuppressWarnings("unchecked")
-  public MaterializerState<Map<String, Integer>, Set<String>> getState() {
-    MaterializerState<ImmutableMap<MaterialKey, InternalCryptoMaterial>, ImmutableSet<MaterialKey>>
-        materializerState = getImmutableState();
-    
-    ImmutableMap<MaterialKey, InternalCryptoMaterial> materializedState = materializerState.getMaterializedState();
-    Map<String, Integer> occurencies = new HashMap<>(materializedState.size());
-    ImmutableSet<Map.Entry<MaterialKey, InternalCryptoMaterial>> entrySet = materializedState.entrySet();
-    entrySet.stream()
-        .forEach(es ->
-            occurencies.put(es.getKey().getExtendedUsername(), es.getValue().references));
-    
-    ImmutableSet<MaterialKey> scheduledRemovals = materializerState.getScheduledRemovals();
-    Set<String> removals = scheduledRemovals.stream()
-        .map(mt -> mt.getExtendedUsername())
-        .collect(Collectors.toSet());
-    
-    return new MaterializerState<>(occurencies, removals);
-  }
-  
-  @Lock(LockType.WRITE)
-  private MaterializerState getImmutableState() {
-    ImmutableMap<MaterialKey, InternalCryptoMaterial> materializedState = ImmutableMap.copyOf(materialMap);
-    ImmutableSet<MaterialKey> scheduledRemovals = ImmutableSet.copyOf(scheduledFileRemovers.keySet());
-    return new MaterializerState<ImmutableMap<MaterialKey, InternalCryptoMaterial>, ImmutableSet<MaterialKey>>(
-        materializedState, scheduledRemovals);
-  }
-  
-  public class MaterializerState<T, S> {
-    private final T materializedState;
-    private final S scheduledRemovals;
-    
-    MaterializerState(T materializedState, S scheduledRemovals) {
-      this.materializedState = materializedState;
-      this.scheduledRemovals = scheduledRemovals;
-    }
-    
-    public T getMaterializedState() {
-      return materializedState;
-    }
-    
-    public S getScheduledRemovals() {
-      return scheduledRemovals;
+    @Override
+    public void run() {
+      deleteMaterialFromLocalFs(key, materializationDirectory);
+      Map<String, Runnable> materialRemovers = fileRemovers.get(key);
+      if (materialRemovers != null) {
+        materialRemovers.remove(materializationDirectory);
+        if (materialRemovers.isEmpty()) {
+          fileRemovers.remove(key);
+        }
+        LOG.log(Level.FINEST, "Deleted crypto material for <" + key.getExtendedUsername() + "> from directory "
+            + materializationDirectory);
+      }
     }
   }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/RemoteMaterialReferencesFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/RemoteMaterialReferencesFacade.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of HopsWorks
+ *
+ * Copyright (C) 2013 - 2018, Logical Clocks AB and RISE SICS AB. All rights reserved.
+ *
+ * HopsWorks is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HopsWorks is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with HopsWorks.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.hops.hopsworks.common.security;
+
+import io.hops.hopsworks.common.security.dao.RemoteMaterialRefID;
+import io.hops.hopsworks.common.security.dao.RemoteMaterialReferences;
+
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Stateless
+@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+public class RemoteMaterialReferencesFacade {
+  private final static Logger LOG = Logger.getLogger(RemoteMaterialReferencesFacade.class.getName());
+  
+  @PersistenceContext(unitName = "kthfsPU")
+  private EntityManager entityManager;
+  
+  public RemoteMaterialReferencesFacade() {
+  }
+  
+  public RemoteMaterialReferences findById(RemoteMaterialRefID identifier) {
+    RemoteMaterialReferences result = entityManager.find(RemoteMaterialReferences.class, identifier);
+    return result;
+  }
+  
+  public void persist(RemoteMaterialReferences materialReferences) {
+    entityManager.persist(materialReferences);
+  }
+  
+  @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+  public void update(RemoteMaterialReferences materialReferences) {
+    entityManager.merge(materialReferences);
+  }
+  
+  @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+  public void delete(RemoteMaterialRefID identifier) {
+    RemoteMaterialReferences materialReferences = findById(identifier);
+    if (materialReferences != null) {
+      entityManager.remove(materialReferences);
+    }
+  }
+  
+  @TransactionAttribute(TransactionAttributeType.REQUIRED)
+  public List<RemoteMaterialReferences> findAll() {
+    TypedQuery<RemoteMaterialReferences> query = entityManager.createNamedQuery("RemoteMaterialReferences.findAll",
+        RemoteMaterialReferences.class);
+    return query.getResultList();
+  }
+  
+  public void createNewMaterialReference(RemoteMaterialRefID identifier) {
+    RemoteMaterialReferences ref = new RemoteMaterialReferences(identifier);
+    entityManager.persist(ref);
+  }
+  
+  public RemoteMaterialReferences acquireLock(RemoteMaterialRefID identifier, String lockId)
+      throws AcquireLockException {
+    RemoteMaterialReferences ref = entityManager.find(RemoteMaterialReferences.class, identifier);
+    if (ref != null) {
+      if (ref.getLock() && !lockId.equals(ref.getLockId())) {
+        throw new AcquireLockException("Could not get lock for <" + identifier + ">");
+      } else {
+        ref.setLock(true);
+        ref.setLockId(lockId);
+        return entityManager.merge(ref);
+      }
+    }
+    
+    return null;
+  }
+  
+  @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+  public void releaseLock(RemoteMaterialRefID identifier, String lockId) throws AcquireLockException {
+    RemoteMaterialReferences ref = entityManager.find(RemoteMaterialReferences.class, identifier);
+    if (ref != null) {
+      if (ref.getLock() && lockId.equals(ref.getLockId())) {
+        ref.setLock(false);
+        ref.setLockId("");
+        entityManager.merge(ref);
+      } else {
+        throw new AcquireLockException("Could not release lock. I does not belong to " + lockId);
+      }
+    } else {
+      LOG.log(Level.WARNING, "Tried to release lock for non-existing reference: " + identifier);
+    }
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/dao/RemoteMaterialRefID.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/dao/RemoteMaterialRefID.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of HopsWorks
+ *
+ * Copyright (C) 2013 - 2018, Logical Clocks AB and RISE SICS AB. All rights reserved.
+ *
+ * HopsWorks is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HopsWorks is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with HopsWorks.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.hops.hopsworks.common.security.dao;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class RemoteMaterialRefID implements Serializable {
+  private static final long serialVersionUID = 1L;
+  
+  @Column(name = "username",
+          nullable = false,
+          length = 128)
+  private String username;
+  
+  @Column(name = "path",
+          nullable = false)
+  private String path;
+  
+  public RemoteMaterialRefID() {
+  }
+  
+  public RemoteMaterialRefID(String username, String path) {
+    this.username = username;
+    this.path = path;
+  }
+  
+  public String getUsername() {
+    return username;
+  }
+  
+  public void setUsername(String username) {
+    this.username = username;
+  }
+  
+  public String getPath() {
+    return path;
+  }
+  
+  public void setPath(String path) {
+    this.path = path;
+  }
+  
+  @Override
+  public int hashCode() {
+    return Objects.hash(username, path);
+  }
+  
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    
+    if (other instanceof RemoteMaterialRefID) {
+      return username.equals(((RemoteMaterialRefID) other).getUsername())
+          && path.equals(((RemoteMaterialRefID) other).getPath());
+    }
+    
+    return false;
+  }
+  
+  @Override
+  public String toString() {
+    return "Username <" + username + ">, Path <" + path + ">";
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/dao/RemoteMaterialReferences.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/dao/RemoteMaterialReferences.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of HopsWorks
+ *
+ * Copyright (C) 2013 - 2018, Logical Clocks AB and RISE SICS AB. All rights reserved.
+ *
+ * HopsWorks is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HopsWorks is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with HopsWorks.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.hops.hopsworks.common.security.dao;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "hopsworks.remote_material_references")
+@XmlRootElement
+@NamedQueries({
+    @NamedQuery(name = "RemoteMaterialReferences.findAll",
+                query = "SELECT r FROM RemoteMaterialReferences r")})
+public class RemoteMaterialReferences implements Serializable {
+  private static final long serialVersionUID = 1L;
+  
+  @EmbeddedId
+  private RemoteMaterialRefID identifier;
+  
+  @Column(name = "`references`",
+          nullable = false)
+  @Basic(optional = false)
+  private Integer references;
+  
+  @Column(name = "`lock`",
+          nullable = false)
+  @Basic(optional = false)
+  private boolean lock;
+  
+  @Column(name = "lock_id",
+          nullable = false,
+          length = 30)
+  private String lockId;
+  
+  public RemoteMaterialReferences() {
+  }
+  
+  public RemoteMaterialReferences(RemoteMaterialRefID identifier) {
+    this.identifier = identifier;
+    this.references = -1;
+    this.lock = false;
+    this.lockId = "";
+  }
+  
+  public RemoteMaterialRefID getIdentifier() {
+    return identifier;
+  }
+  
+  public void setIdentifier(RemoteMaterialRefID identifier) {
+    this.identifier = identifier;
+  }
+  
+  public Integer getReferences() {
+    return references;
+  }
+  
+  public void setReferences(Integer references) {
+    this.references = references;
+  }
+  
+  public boolean getLock() {
+    return lock;
+  }
+  
+  public void setLock(boolean lock) {
+    this.lock = lock;
+  }
+  
+  public String getLockId() {
+    return lockId;
+  }
+  
+  public void setLockId(String lockId) {
+    this.lockId = lockId;
+  }
+  
+  public void incrementReferences() {
+    ++references;
+  }
+  
+  public Integer decrementReferences() {
+    return --references;
+  }
+}

--- a/hopsworks-common/src/main/resources/META-INF/persistence.xml
+++ b/hopsworks-common/src/main/resources/META-INF/persistence.xml
@@ -96,6 +96,7 @@
     <class>io.hops.hopsworks.common.dao.host.Hosts</class>
     <class>io.hops.hopsworks.common.dao.kagent.HostServices</class>
     <class>io.hops.hopsworks.common.dao.user.security.UserGroup</class>
+    <class>io.hops.hopsworks.common.security.dao.RemoteMaterialReferences</class>
     <!-- Converters -->
     <class>io.hops.hopsworks.common.dao.tfserving.TfServingStatusConverter</class>
     <class>io.hops.hopsworks.common.dao.user.cluster.RegistrationStatusConverter</class>


### PR DESCRIPTION
[HOPSWORKS-438]  Materialization in the local filesystem

[HOPSWORKS-438]  Fix synchronization and file removal bug

[HOPSWORKS-438]  Materialize certificates on HDFS

[HOPSWORKS-438]  Remove sync from HDFS

[HOPSWORKS-438]  Implement row exclusive locking for remote material references

[HOPSWORKS-438]  Cleanup code

[HOPSWORKS-438]  Refactor it a little bit

[HOPSWORKS-438]  Replace old CertificateMaterializer

[HOPSWORKS-438]  Fix bugs with persisting to the DB

[HOPSWORKS-438]  Get Materializer state for local certificates

[HOPSWORKS-438]  Get state of the Materializer and fix bug when cancelling removal

[HOPSWORKS-438]  CertificateMaterializer service admin to force remove material

[HOPSWORKS-438]  Fix bug with infinite loop when trying to delete remote material that does not exist

[HOPSWORKS-438]  Truncate lock identifier to fit the column size in DB and fix downloading certificates

[HOPSWORKS-438]  Reorganizing code and add license header

[HOPSWORKS-438]  JavaDoc for public APIs of CertificateMaterializer

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**

https://hopshadoop.atlassian.net/browse/HOPSWORKS-438

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improves the CertificateMaterializer service of Hopsworks.

* **What is the new behavior (if this is a feature change)?**
CertificateMaterializer can materialize certificates from the database into multiple target directories keeping track of the references to them and caching the raw data. Also, it accounts for the certificates put in HDFS for applications to localize them.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
If you need the certificates in local filesystem or in HDFS you should go through this service. The public API is documented

* **Other information**:
The PR depends on https://github.com/hopshadoop/hopsworks-chef/pull/148 of hopsworks-chef to create the supporting table in the database
