### PR TITLE
[HOPSWORKS-420]  Materialize Jupyter certificates in a custom directory

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
@@ -90,6 +90,7 @@ public class JupyterConfigFilesGenerator {
   private final String runDirPath;
   private final String logDirPath;
   private final int port;
+  private final String certificatesDir;
   private long pid;
   private String secret;
   private String token;
@@ -113,6 +114,7 @@ public class JupyterConfigFilesGenerator {
     confDirPath = notebookPath + File.separator + "conf";
     logDirPath = notebookPath + File.separator + "logs";
     runDirPath = notebookPath + File.separator + "run";
+    certificatesDir = notebookPath + File.separator + "certificates";
     this.token = token;
     try {
       blacklistedSparkProperties = readBlacklistedSparkProperties();
@@ -256,6 +258,7 @@ public class JupyterConfigFilesGenerator {
     new File(confDirPath + "/custom").mkdirs();
     new File(runDirPath).mkdirs();
     new File(logDirPath).mkdirs();
+    new File(certificatesDir).mkdirs();
     return true;
   }
 
@@ -746,4 +749,7 @@ public class JupyterConfigFilesGenerator {
     return notebookPath;
   }
 
+  public String getCertificatesDir() {
+    return certificatesDir;
+  }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterDTO.java
@@ -35,11 +35,12 @@ public class JupyterDTO {
   private long pid=0;
   private String hostIp="";
   private String secret="";
-
+  private String certificatesDir;
+  
   public JupyterDTO() {
   }
 
-  public JupyterDTO(int port, String token, long pid, String secret) {
+  public JupyterDTO(int port, String token, long pid, String secret, String certificatesDir) {
     this.port = port;
     this.token = token;
     this.pid = pid;
@@ -49,6 +50,7 @@ public class JupyterDTO {
     } catch (UnknownHostException ex) {
       Logger.getLogger(JupyterDTO.class.getName()).log(Level.SEVERE, null, ex);
     }
+    this.certificatesDir = certificatesDir;
   }
 
   public String getHostIp() {
@@ -91,4 +93,7 @@ public class JupyterDTO {
     this.secret = secret;
   }
   
+  public String getCertificatesDir() {
+    return certificatesDir;
+  }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterProcessMgr.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterProcessMgr.java
@@ -214,7 +214,7 @@ public class JupyterProcessMgr {
             jc.getSettings().getHadoopSymbolicLinkDir() + "-" + settings.getHadoopVersion(), settings.getJavaHome(),
             settings.getAnacondaProjectDir(project.getName()), port.
             toString(),
-            hdfsUser + "-" + port + ".log", secretDir};
+            hdfsUser + "-" + port + ".log", secretDir, jc.getCertificatesDir()};
       logger.log(Level.INFO, Arrays.toString(command));
       ProcessBuilder pb = new ProcessBuilder(command);
       String pidfile = jc.getRunDirPath() + "/jupyter.pid";
@@ -282,7 +282,7 @@ public class JupyterProcessMgr {
       jc.setToken(token);
     }
 
-    return new JupyterDTO(jc.getPort(), jc.getToken(), jc.getPid(), secretConfig);
+    return new JupyterDTO(jc.getPort(), jc.getToken(), jc.getPid(), secretConfig, jc.getCertificatesDir());
   }
 
   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
@@ -303,7 +303,6 @@ public class JupyterProcessMgr {
   /**
    * This method both stops any jupyter server for a proj_user
    *
-   * @param hdfsUser
    * @throws AppException
    */
 //  @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/HopsUtils.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/HopsUtils.java
@@ -244,14 +244,20 @@ public class HopsUtils {
    * @param certificateMaterializer
    * @throws IOException
    */
-  public static void cleanupCertificatesForUser(String username,
-      String projectName, String remoteFSDir, CertificateMaterializer certificateMaterializer) throws IOException {
+  public static void cleanupCertificatesForUserCustomDir(String username,
+      String projectName, String remoteFSDir, CertificateMaterializer certificateMaterializer, String directory) throws
+      IOException {
 
-    certificateMaterializer.removeCertificatesLocal(username, projectName);
+    certificateMaterializer.removeCertificatesLocalCustomDir(username, projectName, directory);
     String projectSpecificUsername = projectName + HdfsUsersController
         .USER_NAME_DELIMITER + username;
     String remoteDirectory = remoteFSDir + Path.SEPARATOR + projectSpecificUsername;
     certificateMaterializer.removeCertificatesRemote(username, projectName, remoteDirectory);
+  }
+  
+  public static void cleanupCertificatesForUser(String username, String projectName, String remoteFSDir,
+      CertificateMaterializer certificateMaterializer) throws IOException {
+    cleanupCertificatesForUserCustomDir(username, projectName, remoteFSDir, certificateMaterializer, null);
   }
   
   /**
@@ -264,19 +270,26 @@ public class HopsUtils {
    * @param settings
    * @throws IOException
    */
-  public static void materializeCertificatesForUser(String projectName, String userName, String remoteFSDir,
+  public static void materializeCertificatesForUserCustomDir(String projectName, String userName, String remoteFSDir,
       DistributedFileSystemOps dfso, CertificateMaterializer
-      certificateMaterializer, Settings settings) throws
+      certificateMaterializer, Settings settings, String directory) throws
       IOException {
 
     String projectSpecificUsername = projectName + "__" + userName;
   
-    certificateMaterializer.materializeCertificatesLocal(userName, projectName);
+    certificateMaterializer.materializeCertificatesLocalCustomDir(userName, projectName, directory);
     
     
     String remoteDirectory = createRemoteDirectory(remoteFSDir, projectSpecificUsername, projectSpecificUsername, dfso);
     certificateMaterializer.materializeCertificatesRemote(userName, projectName, projectSpecificUsername,
         projectSpecificUsername, materialPermissions, remoteDirectory);
+  }
+  
+  public static void materializeCertificatesForUser(String projectName, String userName, String remoteFSDir,
+      DistributedFileSystemOps dfso, CertificateMaterializer certificateMaterializer, Settings settings)
+    throws IOException {
+    materializeCertificatesForUserCustomDir(projectName, userName, remoteFSDir, dfso, certificateMaterializer,
+        settings, null);
   }
   
   /**


### PR DESCRIPTION
Materialize Jupyter certificates in a custom directoryry, in Project's secret dir

[HOPSWORKS-420]  Pass certificates directory to start Jupyter bash script

[HOPSWORKS-420]  Materialize certificates also in the standard directory so Livy can pick them up

[HOPSWORKS-420]  Put back release version of Hops

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-420

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Certificates used in Jupyter are now materialized in Jupyter Project's secret directory.

* **What is the new behavior (if this is a feature change)?**
'jupyter' user will no longer be in 'certs' group, thus not able to read other users' certificates. The directory where the certificates are materialized is exported by an environment variable which is picked by HopsSSLSocketFactory
