### PR TITLE
HOPSWORKS-459 set correct values for TensorFlowOnSpark and Horovod in JupyterSettings

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/JupyterSettings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/JupyterSettings.java
@@ -140,13 +140,13 @@ public class JupyterSettings implements Serializable {
   protected JupyterSettingsPK jupyterSettingsPK;
   @Basic(optional = false)
   @Column(name = "num_tf_ps")
-  private int numTfPs = 0;
+  private int numTfPs = 1;
   @Basic(optional = false)
   @Column(name = "num_tf_gpus")
   private int numTfGpus = 0;
   @Basic(optional = false)
   @Column(name = "num_mpi_np")
-  private int numMpiNp = 0;
+  private int numMpiNp = 1;
   @Basic(optional = false)
   @Column(name = "appmaster_cores")
   private int appmasterCores = 1;


### PR DESCRIPTION
HOPSWORKS-382 changed the default values to 0 the number of parameter servers and mpi processes, meaning that default configuration was not a runnable configuration. (Can't run horovod with 0 processes or TFoS with 0 parameter servers)

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
