### PR TITLE
HOPSWORKS-462

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/hopssite/dto/LocalDatasetHelper.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/hopssite/dto/LocalDatasetHelper.java
@@ -39,7 +39,7 @@ public class LocalDatasetHelper {
       Path path = datasetCtrl.getDatasetPath(d);
       long size;
       try {
-        size = dfso.getDatasetSize(path);
+        size = dfso.getLastUpdatedDatasetSize(path);
       } catch (IOException ex) {
         size = -1;
       }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFileSystemOps.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFileSystemOps.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.LastUpdatedContentSummary;
 import org.apache.hadoop.security.UserGroupInformation;
 
 public class DistributedFileSystemOps {
@@ -657,5 +658,10 @@ public class DistributedFileSystemOps {
   public long getDatasetSize(Path datasetPath) throws IOException {
     ContentSummary cs = dfs.getContentSummary(datasetPath);
     return cs.getLength();
+  }
+  
+  public long getLastUpdatedDatasetSize(Path datasetPath) throws IOException {
+    LastUpdatedContentSummary cs = dfs.getLastUpdatedContentSummary(datasetPath);
+    return cs.getSpaceConsumed();
   }
 }


### PR DESCRIPTION
Use quota cached dataset size as a fast approximation of the dataset's size. When requiring the size of many possibly large datasets getting the real dataset can be very slow. See dela - cluster-published datasets.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
