### PR TITLE
[HOPSWORKS-454]  Service certificate rotation

### DIFF
--- a/hopsworks-admin/src/main/java/io/hops/hopsworks/admin/maintenance/NodesBean.java
+++ b/hopsworks-admin/src/main/java/io/hops/hopsworks/admin/maintenance/NodesBean.java
@@ -22,6 +22,7 @@ package io.hops.hopsworks.admin.maintenance;
 import io.hops.hopsworks.admin.lims.MessagesController;
 import io.hops.hopsworks.common.dao.host.Hosts;
 import io.hops.hopsworks.common.dao.host.HostsFacade;
+import io.hops.hopsworks.common.security.CertificatesMgmService;
 import io.hops.hopsworks.common.util.Settings;
 import java.io.BufferedReader;
 import java.io.File;
@@ -61,6 +62,8 @@ public class NodesBean implements Serializable {
   private HostsFacade hostsFacade;
   @EJB
   private Settings settings;
+  @EJB
+  private CertificatesMgmService certificatesMgmService;
 
   private List<Hosts> allNodes;
   private final Map<String, Object> dialogOptions;
@@ -231,5 +234,11 @@ public class NodesBean implements Serializable {
         MessagesController.addErrorMessage("Could not delete node");
       }
     }
+  }
+  
+  public void rotateKeys() {
+    certificatesMgmService.issueServiceKeyRotationCommand();
+    MessagesController.addInfoMessage("Commands issued", "Issued command to rotate keys on hosts");
+    logger.log(Level.INFO, "Issued key rotation command");
   }
 }

--- a/hopsworks-admin/src/main/webapp/security/protected/admin/hostsManagement.xhtml
+++ b/hopsworks-admin/src/main/webapp/security/protected/admin/hostsManagement.xhtml
@@ -71,12 +71,20 @@
                                     style="float:left"/>
                     </div>
                   </div>
+		  
                   <div class="ui-g-12 ui-md-2">
+		    <p:commandButton value="Rotate host keys"
+                                     style="float:right" 
+                                     actionListener="#{nodesBean.rotateKeys}"
+				     icon="ui-icon-arrowrefresh-1-w"
+				     update=":manageClusterNodes:growl">
+		    </p:commandButton>
                     <p:commandButton value="Zip Anaconda Libraries"
                                      style="float:right" 
                                      actionListener="#{nodesBean.zipUpAnacondaLibs}" ajax ="true" update="@all">
                     </p:commandButton>
                   </div>
+		  
                 </div>
 
                 <p:dataTable id="nodesTable" var="node"

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/SystemAdminService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/SystemAdminService.java
@@ -254,4 +254,14 @@ public class SystemAdminService {
     GenericEntity<Hosts> response = new GenericEntity<Hosts>(finalNode){};
     return noCacheResponse.getNoCacheResponseBuilder(Response.Status.CREATED).entity(response).build();
   }
+  
+  @POST
+  @Path("/rotate")
+  public Response serviceKeyRotate(@Context SecurityContext sc, @Context HttpServletRequest request)
+    throws AppException {
+    certificatesMgmService.issueServiceKeyRotationCommand();
+    JsonResponse response = noCacheResponse.buildJsonResponse(Response.Status.NO_CONTENT, "Key rotation commands " +
+        "issued");
+    return noCacheResponse.getNoCacheResponseBuilder(Response.Status.NO_CONTENT).entity(response).build();
+  }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommand.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommand.java
@@ -88,6 +88,13 @@ public class SystemCommand implements Serializable {
           length = 50)
   private String execUser;
   
+  public SystemCommand(Hosts host, SystemCommandFacade.OP op) {
+    this.status = SystemCommandFacade.STATUS.ONGOING;
+    this.priority = 0;
+    this.host = host;
+    this.op = op;
+  }
+  
   public SystemCommand() {
     this.status = SystemCommandFacade.STATUS.ONGOING;
     this.priority = 0;
@@ -95,6 +102,10 @@ public class SystemCommand implements Serializable {
   
   public Integer getId() {
     return id;
+  }
+  
+  public void setId(Integer id) {
+    this.id = id;
   }
   
   public Hosts getHost() {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommandFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommandFacade.java
@@ -22,6 +22,8 @@ package io.hops.hopsworks.common.dao.command;
 import io.hops.hopsworks.common.dao.host.Hosts;
 
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
@@ -66,7 +68,11 @@ public class SystemCommandFacade {
     entityManager.merge(command);
   }
   
+  @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
   public void delete(SystemCommand command) {
-    entityManager.remove(command);
+    SystemCommand deleteCommand = entityManager.find(SystemCommand.class, command.getId());
+    if (deleteCommand != null) {
+      entityManager.remove(deleteCommand);
+    }
   }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDepsFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDepsFacade.java
@@ -26,6 +26,7 @@ import io.hops.hopsworks.common.dao.project.Project;
 import io.hops.hopsworks.common.dao.project.ProjectFacade;
 import io.hops.hopsworks.common.exception.AppException;
 import io.hops.hopsworks.common.util.HopsUtils;
+
 import java.util.List;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
@@ -625,7 +626,7 @@ public class PythonDepsFacade {
       // do nothing - already uninstalled
     }
   }
-
+  
   private void condaOp(CondaOp op, CondaInstallType installType, MachineType machineType, Project proj,
                        String channelUrl, String lib, String version) throws AppException {
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -80,15 +80,7 @@ import java.util.regex.Pattern;
 @DependsOn("Settings")
 public class CertificateMaterializer {
   private static final Logger LOG = Logger.getLogger(CertificateMaterializer.class.getName());
-  private static final Map<String, TimeUnit> TIME_SUFFIXES;
-  static {
-    TIME_SUFFIXES = new HashMap<>(5);
-    TIME_SUFFIXES.put("ms", TimeUnit.MILLISECONDS);
-    TIME_SUFFIXES.put("s", TimeUnit.SECONDS);
-    TIME_SUFFIXES.put("m", TimeUnit.MINUTES);
-    TIME_SUFFIXES.put("h", TimeUnit.HOURS);
-    TIME_SUFFIXES.put("d", TimeUnit.DAYS);
-  }
+  
   private final static String KEYSTORE_SUFFIX = "__kstore.jks";
   private final static String TRUSTSTORE_SUFFIX = "__tstore.jks";
   private final static String CERT_PASS_SUFFIX = "__cert.key";
@@ -208,20 +200,8 @@ public class CertificateMaterializer {
     }
     transientDir = tmpDir.getAbsolutePath();
     String delayRaw = settings.getCertificateMaterializerDelay();
-    
-    Matcher matcher = Pattern.compile("([0-9]+)([a-z]+)?").matcher(delayRaw
-        .toLowerCase());
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException("Invalid delay value: " + delayRaw);
-    }
-    
-    DELAY_VALUE = Long.parseLong(matcher.group(1));
-    String timeUnitStr = matcher.group(2);
-    if (null != timeUnitStr && !TIME_SUFFIXES.containsKey(timeUnitStr)) {
-      throw new IllegalArgumentException("Invalid delay suffix: " + timeUnitStr);
-    }
-    DELAY_TIMEUNIT = timeUnitStr == null ? TimeUnit.MINUTES : TIME_SUFFIXES
-        .get(timeUnitStr);
+    DELAY_VALUE = Settings.getConfTimeValue(delayRaw);
+    DELAY_TIMEUNIT = Settings.getConfTimeTimeUnit(delayRaw);
     
     try {
       String hostAddress = InetAddress.getLocalHost().getHostAddress();

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/ServiceCertificateRotationTimer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/ServiceCertificateRotationTimer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2013 - 2018, Logical Clocks AB and RISE SICS AB. All rights reserved
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS  OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package io.hops.hopsworks.common.security;
+
+import io.hops.hopsworks.common.util.Settings;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.DependsOn;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Singleton
+@Startup
+@DependsOn("Settings")
+public class ServiceCertificateRotationTimer {
+  private final static Logger LOG = Logger.getLogger(ServiceCertificateRotationTimer.class.getName());
+  
+  @Resource
+  private TimerService timerService;
+  @EJB
+  private Settings settings;
+  @EJB
+  private CertificatesMgmService certificatesMgmService;
+  
+  @PostConstruct
+  public void init() {
+    String rawInterval = settings.getServiceKeyRotationInterval();
+    Long intervalValue = Settings.getConfTimeValue(rawInterval);
+    TimeUnit intervalTimeunit = Settings.getConfTimeTimeUnit(rawInterval);
+    LOG.log(Level.INFO, "Service certificate rotation is configured to run every " + intervalValue + " " +
+        intervalTimeunit.name());
+    
+    intervalValue = intervalTimeunit.toMillis(intervalValue);
+    timerService.createTimer(intervalValue, intervalValue, "Service certificate rotation");
+  }
+  
+  @Timeout
+  public void rotate(Timer timer) {
+    LOG.log(Level.FINEST, "Rotating service certificates");
+    certificatesMgmService.issueServiceKeyRotationCommand();
+  }
+}


### PR DESCRIPTION
[HOPSWORKS-454]  Add REST endpoint for service certificate rotation
[HOPSWORKS-454]  Going to extend the heartbeat protocol of kagent
[HOPSWORKS-454]  Pull kagent heartbeat protocol changes
[HOPSWORKS-454]  Process system commands in heartbeat and issue service key rotation commands
[HOPSWORKS-454]  Schedule periodic service key rotation
[HOPSWORKS-454]  Add button in admin panel to rotate host keys
[HOPSWORKS-454]  Add argument to script signing service csr
[HOPSWORKS-454]  Decrease validity period only for service certificates and not for Dela

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-454

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature

* **What is the new behavior (if this is a feature change)?**
Service/Host certificates are automatically rotated every two days (configurable) or when requested from the Admin panel>Hosts management.

The rotation command is sent with kagent heartbeat protocol

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Changed the script `$DOMAIN1/bin/global-ca-sign-csr.sh` to take the number of valid days for a certificate as an argument. If you do not change the script above, Host registration will fail.

* **Other information**:
Depend on the following PR:
1) https://github.com/hopshadoop/kagent-chef/pull/30
2) https://github.com/hopshadoop/hopsworks-chef/pull/156
