### PR TITLE
[HOPSWORKS-461] Remove the execution of kagent commands from the Heartbeat loop

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommand.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommand.java
@@ -89,14 +89,14 @@ public class SystemCommand implements Serializable {
   private String execUser;
   
   public SystemCommand(Hosts host, SystemCommandFacade.OP op) {
-    this.status = SystemCommandFacade.STATUS.ONGOING;
+    this.status = SystemCommandFacade.STATUS.NEW;
     this.priority = 0;
     this.host = host;
     this.op = op;
   }
   
   public SystemCommand() {
-    this.status = SystemCommandFacade.STATUS.ONGOING;
+    this.status = SystemCommandFacade.STATUS.NEW;
     this.priority = 0;
   }
   

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommandFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/command/SystemCommandFacade.java
@@ -37,6 +37,7 @@ public class SystemCommandFacade {
   }
   
   public enum STATUS {
+   NEW,
    ONGOING,
    FINISHED,
    FAILED

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/CondaCommands.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/CondaCommands.java
@@ -81,7 +81,9 @@ import javax.xml.bind.annotation.XmlRootElement;
           = "SELECT c FROM CondaCommands c WHERE c.status = :status"),
   @NamedQuery(name = "CondaCommands.findByCreated",
           query
-          = "SELECT c FROM CondaCommands c WHERE c.created = :created")})
+          = "SELECT c FROM CondaCommands c WHERE c.created = :created"),
+  @NamedQuery(name = "CondaCommands.findByHost",
+          query = "SELECT c FROM CondaCommands c WHERE c.hostId = :host")})
 public class CondaCommands implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDep.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDep.java
@@ -99,7 +99,7 @@ public class PythonDep implements Serializable {
   @Column(name = "status")
   @Enumerated(EnumType.ORDINAL)
   private PythonDepsFacade.CondaStatus status
-          = PythonDepsFacade.CondaStatus.ONGOING;
+          = PythonDepsFacade.CondaStatus.NEW;
 
   @Column(name = "install_type")
   @Enumerated(EnumType.ORDINAL)

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDepsFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/pythonDeps/PythonDepsFacade.java
@@ -105,6 +105,7 @@ public class PythonDepsFacade {
   }
 
   public enum CondaStatus {
+    NEW,
     SUCCESS,
     ONGOING,
     FAILED
@@ -333,7 +334,7 @@ public class PythonDepsFacade {
         }
       }
       for (CondaCommands cc : failedCCs) {
-        cc.setStatus(CondaStatus.ONGOING);
+        cc.setStatus(CondaStatus.NEW);
         em.merge(cc);
       }
     }
@@ -483,7 +484,7 @@ public class PythonDepsFacade {
     for (Hosts h : getHosts()) {
       // For environment operations, we don't care about the Conda Channel, so we just pick 'defaults'
       CondaCommands cc = new CondaCommands(h, settings.getAnacondaUser(),
-          op, CondaStatus.ONGOING, CondaInstallType.ENVIRONMENT, MachineType.ALL, proj, pythonVersion, "",
+          op, CondaStatus.NEW, CondaInstallType.ENVIRONMENT, MachineType.ALL, proj, pythonVersion, "",
               "defaults", new Date(), arg);
       em.persist(cc);
     }
@@ -670,7 +671,7 @@ public class PythonDepsFacade {
 
       for (Hosts h : hosts) {
         CondaCommands cc = new CondaCommands(h, settings.getAnacondaUser(),
-            op, CondaStatus.ONGOING, installType, machineType, proj, lib,
+            op, CondaStatus.NEW, installType, machineType, proj, lib,
             version, channelUrl, new Date(), "");
         em.persist(cc);
       }
@@ -808,6 +809,14 @@ public class PythonDepsFacade {
     }
   }
 
+  @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+  public List<CondaCommands> findByHost(Hosts host) {
+    TypedQuery<CondaCommands> query = em.createNamedQuery("CondaCommands.findByHost",
+        CondaCommands.class);
+    query.setParameter("host", host);
+    return query.getResultList();
+  }
+  
 //  public void updateCondaComamandStatus(int commandId, String status, String arg) {
 //    PythonDepsFacade.CondaStatus s = PythonDepsFacade.CondaStatus.valueOf(
 //            status.toUpperCase());


### PR DESCRIPTION
[HOPSWORKS-461]  Introduce NEW status for kagent commands
[HOPSWORKS-461]  Fix wrong command attribute names
[HOPSWORKS-461] Read NEW Conda commands for heartbeat
[HOPSWORKS-461]  Fix bug with NPE when deleting a project

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-461

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
kagent commands for managing Conda environments or system commands are executed out of the heartbeat loop. Once a command is received, it is put in a queue and is executed when the previous command has finished. kagent keeps heartbeating updating Hopsworks with the host metrics and accepting new commands to be executed.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Commands now have an extra status, the NEW status.

NEW -> ONGOING -> SUCCESS *or* FAILED

* **Other information**:
Dependent on PR https://github.com/hopshadoop/kagent-chef/pull/32
