### PR TITLE
[HOPSWORKS-489] Revoke removed certificates

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/PKIUtils.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/PKIUtils.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -192,7 +193,24 @@ public class PKIUtils {
     }
     return lines.toString();
   }
-
+  
+  public static HashMap<String, String> getKeyValuesFromSubject(String subject) {
+    if (subject == null || subject.isEmpty()) {
+      return null;
+    }
+    String[] parts = subject.split("/");
+    String[] keyVal;
+    HashMap<String, String> keyValStore = new HashMap<>();
+    for (String part : parts) {
+      keyVal = part.split("=");
+      if (keyVal.length < 2) {
+        continue;
+      }
+      keyValStore.put(keyVal[0], keyVal[1]);
+    }
+    return keyValStore;
+  }
+  
   public static String getSerialNumberFromCert(String cert) throws IOException, InterruptedException {
     File csrFile = File.createTempFile(System.getProperty("java.io.tmpdir"), ".pem");
     FileUtils.writeStringToFile(csrFile, cert);


### PR DESCRIPTION
[HOPSWORKS-489] Revoke certificate when user removed from Project
[HOPSWORKS-489] Revoke members of a project when project is removed
[HOPSWORKS-489] Revoke service rotated certificates

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-489

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature

* **What is the new behavior (if this is a feature change)?**
Users, projects, services certificates that are removed from the system are also revoked. The revocation list is available at $DOMAIN1/docroot/intermediate.crl.pem

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

* **Other information**:
hopsworks-chef PR https://github.com/hopshadoop/hopsworks-chef/pull/159
