### PR TITLE
[HOPSWORKS-496]  Auto service certificate rotation configuration

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/ServiceCertificateRotationTimer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/ServiceCertificateRotationTimer.java
@@ -56,7 +56,9 @@ public class ServiceCertificateRotationTimer {
         intervalTimeunit.name());
     
     intervalValue = intervalTimeunit.toMillis(intervalValue);
-    timerService.createTimer(intervalValue, intervalValue, "Service certificate rotation");
+    if (settings.isServiceKeyRotationEnabled()) {
+      timerService.createTimer(intervalValue, intervalValue, "Service certificate rotation");
+    }
   }
   
   @Timeout

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -435,6 +435,7 @@ public class Settings implements Serializable {
       RECOVERY_PATH = setStrVar(VARIABLE_RECOVERY_PATH, RECOVERY_PATH);
       FIRST_TIME_LOGIN = setStrVar(VARIABLE_FIRST_TIME_LOGIN, FIRST_TIME_LOGIN);
       VERIFICATION_PATH = setStrVar(VARIABLE_VERIFICATION_PATH, VERIFICATION_PATH);
+      serviceKeyRotationEnabled = setBoolVar(SERVICE_KEY_ROTATION_ENABLED_KEY, serviceKeyRotationEnabled);
       serviceKeyRotationInterval = setStrVar(SERVICE_KEY_ROTATION_INTERVAL_KEY, serviceKeyRotationInterval);
       populateDelaCache();
       populateLDAPCache();
@@ -2449,6 +2450,14 @@ public class Settings implements Serializable {
     return LDAP_ACCOUNT_STATUS;
   }
   //----------------------------END LDAP------------------------------------
+  
+  // Service key rotation enabled
+  private static final String SERVICE_KEY_ROTATION_ENABLED_KEY = "service_key_rotation_enabled";
+  private boolean serviceKeyRotationEnabled = false;
+  public synchronized boolean isServiceKeyRotationEnabled() {
+    checkCache();
+    return serviceKeyRotationEnabled;
+  }
   
   // Service key rotation interval
   private static final String SERVICE_KEY_ROTATION_INTERVAL_KEY = "service_key_rotation_interval";


### PR DESCRIPTION
[HOPSWORKS-496] Configure enable/disable of service certificate automatic rotation

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-496

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
Configuration option to enable/disable automatic service certificate rotation. Rotation can be done explicitly by the Admin panel

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

* **Other information**:
