### PR TITLE
[HOPSWORKS-502]  Rename old host certificate based on the command ID

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/agent/AgentResource.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/agent/AgentResource.java
@@ -364,7 +364,7 @@ public class AgentResource {
   private void processServiceKeyRotationCommand(SystemCommand command, SystemCommandFacade.STATUS status) {
     if (status.equals(SystemCommandFacade.STATUS.FINISHED)) {
       try {
-        certificatesMgmService.deleteServiceCertificate(command.getHost());
+        certificatesMgmService.deleteServiceCertificate(command.getHost(), command.getId());
       } catch (IOException ex) {
         logger.log(Level.WARNING, "Could not revoke certificate for host: " + command.getHost().getHostname(), ex);
       }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/ServiceCertificateRotationTimer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/ServiceCertificateRotationTimer.java
@@ -30,6 +30,8 @@ import javax.ejb.Startup;
 import javax.ejb.Timeout;
 import javax.ejb.Timer;
 import javax.ejb.TimerService;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,6 +41,7 @@ import java.util.logging.Logger;
 @DependsOn("Settings")
 public class ServiceCertificateRotationTimer {
   private final static Logger LOG = Logger.getLogger(ServiceCertificateRotationTimer.class.getName());
+  private final static String TO_BE_REVOKED = ".cert.pem.TO_BE_REVOKED.{COMMAND_ID}";
   
   @Resource
   private TimerService timerService;
@@ -65,5 +68,10 @@ public class ServiceCertificateRotationTimer {
   public void rotate(Timer timer) {
     LOG.log(Level.FINEST, "Rotating service certificates");
     certificatesMgmService.issueServiceKeyRotationCommand();
+  }
+  
+  @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+  public String getToBeRevokedSuffix(String commandId) {
+    return TO_BE_REVOKED.replaceAll("\\{COMMAND_ID\\}", commandId);
   }
 }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-502

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Command line arguments for csr.py have changed. Also, The REST call towards Hopsworks to rotate the certificate has changed. It includes the command ID, if there is one associated.

* **Other information**:
Depends on https://github.com/hopshadoop/kagent-chef/pull/35
