### PR TITLE
[HOPSWORKS-537] Aggregate Yarn logs in TIME_OUT status

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnJobsMonitor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnJobsMonitor.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 
 @Singleton
 @DependsOn("Settings")
@@ -107,7 +106,7 @@ public class YarnJobsMonitor {
     for (String appID : executions.keySet()) {
       YarnMonitor monitor = monitors.get(appID);
       if (monitor == null) {
-        ApplicationId appId = ConverterUtils.toApplicationId(appID);
+        ApplicationId appId = ApplicationId.fromString(appID);
         YarnClientWrapper newYarnclientWrapper = ycs.getYarnClientSuper(settings
             .getConfiguration());
         monitor = new YarnMonitor(appId, newYarnclientWrapper, ycs);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnLogUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/yarn/YarnLogUtil.java
@@ -101,7 +101,10 @@ public class YarnLogUtil {
           writer.print("The log aggregation failed");
           break;
         case TIME_OUT:
-          writer.print("The log aggregation timedout.");
+          writer.print("*** WARNING: Log aggregation has timed-out for some of the containers\n\n\n");
+          for (String desiredLogType : desiredLogTypes) {
+            writeLogs(dfs, srcs, writer, desiredLogType);
+          }
           break;
         case SUCCEEDED:
           for (String desiredLogType : desiredLogTypes) {
@@ -109,7 +112,7 @@ public class YarnLogUtil {
           }
           break;
         default :
-          writer.print("something went wrond durring the log aggregation.");
+          writer.print("Something went wrong during log aggregation phase!");
       }
     } catch (Exception ex) {
       if (writer != null) {
@@ -146,7 +149,7 @@ public class YarnLogUtil {
         return true;
     }
   }
-
+  
   private static void writeLogs(DistributedFileSystemOps dfs, String[] srcs,
           PrintStream writer, String desiredLogType) {
     ArrayList<AggregatedLogFormat.LogKey> containerNames = new ArrayList<>();


### PR DESCRIPTION
In case of Yarn log aggregation status is TIMEOUT, copy whatever logs are available

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-537

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
Aggregated whatever logs are available when the status is from RM is TIME_OUT. Suffix logs with a warning message.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
