### PR TITLE
[HOPSWORKS-542]  Support for per-Yarn application certificates

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/jupyter/JupyterService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/jupyter/JupyterService.java
@@ -314,7 +314,7 @@ public class JupyterService {
           if (dto != null) {
             HopsUtils.cleanupCertificatesForUserCustomDir(user.getUsername(), project.getName(),
                 settings.getHdfsTmpCertDir(),
-                certificateMaterializer, dto.getCertificatesDir());
+                certificateMaterializer, dto.getCertificatesDir(), settings);
           } else {
             LOGGER.log(Level.SEVERE, "Could not identify local directory to clean certificates. Manual cleanup " +
                 "needed");
@@ -410,7 +410,7 @@ public class JupyterService {
     try {
       String certificatesDir = Paths.get(jupyterHomePath, "certificates").toString();
       HopsUtils.cleanupCertificatesForUserCustomDir(project_user[1], project
-          .getName(), settings.getHdfsTmpCertDir(), certificateMaterializer, certificatesDir);
+          .getName(), settings.getHdfsTmpCertDir(), certificateMaterializer, certificatesDir, settings);
       certificateMaterializer.removeCertificatesLocal(project_user[1], project.getName());
     } catch (IOException e) {
       LOGGER.log(Level.SEVERE, "Could not cleanup certificates for " + hdfsUser);

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/InterpreterRestApi.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/InterpreterRestApi.java
@@ -268,7 +268,7 @@ public class InterpreterRestApi {
         
         HopsUtils
             .cleanupCertificatesForProject(project.getName(),
-                settings.getHdfsTmpCertDir(), certificateMaterializer);
+                settings.getHdfsTmpCertDir(), certificateMaterializer, settings);
         certificateMaterializer.closedInterpreter(project.getId());
       }
     } catch (IOException ex) {
@@ -279,7 +279,7 @@ public class InterpreterRestApi {
       try {
         certificateMaterializer.closedInterpreter(project.getId());
         HopsUtils.cleanupCertificatesForProject(project.getName(), settings.getHdfsTmpCertDir(),
-            certificateMaterializer);
+            certificateMaterializer, settings);
       } catch (IOException ex1) {
         logger.error("Could not clean certificates!", ex1);
       }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/NotebookRestApi.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/rest/NotebookRestApi.java
@@ -635,7 +635,7 @@ public class NotebookRestApi {
                   project.getName() + "__" + username);
               certificateMaterializer.closedInterpreter(project.getId());
               HopsUtils.cleanupCertificatesForProject(project.getName(),
-                  settings.getHdfsTmpCertDir(), certificateMaterializer);
+                  settings.getHdfsTmpCertDir(), certificateMaterializer, settings);
               throw ex;
             }
           }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/server/ZeppelinConfig.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/server/ZeppelinConfig.java
@@ -512,39 +512,29 @@ public class ZeppelinConfig {
         + settings.getHopsUtilFilename();
     
     StringBuilder distFiles = new StringBuilder();
-    distFiles
-        // KeyStore
-        .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
-        .append(projectName)
-        .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
-        .append(File.separator)
-        .append(projectName)
-        .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
-        .append("__kstore.jks#")
-        .append(Settings.K_CERTIFICATE).append(",")
-        // TrustStore
-        .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
-        .append(projectName)
-        .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
-        .append(File.separator)
-        .append(projectName)
-        .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
-        .append("__tstore.jks#")
-        .append(Settings.T_CERTIFICATE)
-        .append(",")
-        // Glassfish domain truststore
-        .append(settings.getGlassfishTrustStoreHdfs())
-        .append("#").append(Settings.DOMAIN_CA_TRUSTSTORE)
-        .append(",")
-        // Add HopsUtil
-        .append(settings.getHopsUtilHdfsPath()).append("#").append(settings.getHopsUtilFilename());
-    
-    // If RPC TLS is enabled, password file would be injected by the
-    // NodeManagers. We don't need to add it as LocalResource
+    // When Hops RPC TLS is enabled, Yarn will take care of application certificate
     if (!settings.getHopsRpcTls()) {
       distFiles
-          // File with crypto material password
+          // KeyStore
+          .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+          .append(projectName)
+          .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
+          .append(File.separator)
+          .append(projectName)
+          .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
+          .append("__kstore.jks#")
+          .append(Settings.K_CERTIFICATE).append(",")
+          // TrustStore
+          .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+          .append(projectName)
+          .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
+          .append(File.separator)
+          .append(projectName)
+          .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
+          .append("__tstore.jks#")
+          .append(Settings.T_CERTIFICATE)
           .append(",")
+          // Material password
           .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
           .append(projectName)
           .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
@@ -552,8 +542,17 @@ public class ZeppelinConfig {
           .append(projectName)
           .append(Settings.PROJECT_GENERIC_USER_SUFFIX)
           .append("__cert.key#")
-          .append(Settings.CRYPTO_MATERIAL_PASSWORD);
+          .append(Settings.CRYPTO_MATERIAL_PASSWORD)
+          .append(",");
     }
+    distFiles
+        // Glassfish domain truststore
+        .append(settings.getGlassfishTrustStoreHdfs())
+        .append("#").append(Settings.DOMAIN_CA_TRUSTSTORE)
+        .append(",")
+        // Add HopsUtil
+        .append(settings.getHopsUtilHdfsPath()).append("#").append(settings.getHopsUtilFilename());
+    
 
     if (interpreterConf == null) {
       StringBuilder interpreter_json = ConfigFileGenerator.

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServerImpl.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/zeppelin/socket/NotebookServerImpl.java
@@ -1622,7 +1622,7 @@ public class NotebookServerImpl implements
         LOG.log(Level.SEVERE, "Error while materializing certificates for Zeppelin", ex);
         certificateMaterializer.closedInterpreter(project.getId());
         HopsUtils.cleanupCertificatesForProject(project.getName(), settings.getHdfsTmpCertDir(),
-            certificateMaterializer);
+            certificateMaterializer, settings);
         throw ex;
       } finally {
         if (null != dfso) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
@@ -320,16 +320,6 @@ public class JupyterConfigFilesGenerator {
   
       StringBuilder sparkFiles = new StringBuilder();
       sparkFiles
-          // Keystore
-          .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
-          .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
-          .append("__kstore.jks#").append(Settings.K_CERTIFICATE)
-          .append(",")
-          // TrustStore
-          .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
-          .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
-          .append("__tstore.jks#").append(Settings.T_CERTIFICATE)
-          .append(",")
           //Log4j.properties
           .append(settings.getSparkLog4JPath())
           .append(",")
@@ -338,17 +328,6 @@ public class JupyterConfigFilesGenerator {
           .append(",")
           // Add HopsUtil
           .append(settings.getHopsUtilHdfsPath());
-  
-      // If RPC TLS is enabled, password file would be injected by the
-      // NodeManagers. We don't need to add it as LocalResource
-      if (!settings.getHopsRpcTls()) {
-        sparkFiles
-            .append(",")
-            // File with crypto material password
-            .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
-            .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
-            .append("__cert.key#").append(Settings.CRYPTO_MATERIAL_PASSWORD);
-      }
   
       if (!js.getFiles().equals("")) {
         //Split the comma-separated string and append it to sparkFiles
@@ -371,6 +350,26 @@ public class JupyterConfigFilesGenerator {
         }
       }
   
+      // If Hops RPC TLS is enabled, password file would be injected by the
+      // NodeManagers. We don't need to add it as LocalResource
+      if (!settings.getHopsRpcTls()) {
+        sparkFiles
+            // Keystore
+            .append(",hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+            .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
+            .append("__kstore.jks#").append(Settings.K_CERTIFICATE)
+            .append(",")
+            // TrustStore
+            .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+            .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
+            .append("__tstore.jks#").append(Settings.T_CERTIFICATE)
+            .append(",")
+            // File with crypto material password
+            .append("hdfs://").append(settings.getHdfsTmpCertDir()).append(File.separator)
+            .append(this.hdfsUser).append(File.separator).append(this.hdfsUser)
+            .append("__cert.key#").append(Settings.CRYPTO_MATERIAL_PASSWORD);
+      }
+      
       //Prepare pyfiles
       StringBuilder pyFilesBuilder = new StringBuilder();
       if (!Strings.isNullOrEmpty(js.getPyFiles())) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/flink/AbstractYarnClusterDescriptor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/flink/AbstractYarnClusterDescriptor.java
@@ -524,15 +524,18 @@ public abstract class AbstractYarnClusterDescriptor implements
   
     Map<String, String> jobSystemProperties = new HashMap<>(3);
   
+    // When Hops RPC TLS is enabled, Yarn will take care of application certificate
     // Certificates are materialized locally so DFSClient can be set to null
     // LocalResources are not used by Flink, so set it null
-    HopsUtils.copyProjectUserCerts(project, username,
-        services.getSettings().getHopsworksTmpCertDir(),
-        services.getSettings().getHdfsTmpCertDir(), JobType.FLINK,
-        null, null, jobSystemProperties,
-        services.getSettings().getFlinkKafkaCertDir(),
-        appResponse.getApplicationId().toString(),
-        services.getCertificateMaterializer(), services.getSettings().getHopsRpcTls());
+    if (!services.getSettings().getHopsRpcTls()) {
+      HopsUtils.copyProjectUserCerts(project, username,
+          services.getSettings().getHopsworksTmpCertDir(),
+          services.getSettings().getHdfsTmpCertDir(), JobType.FLINK,
+          null, null, jobSystemProperties,
+          services.getSettings().getFlinkKafkaCertDir(),
+          appResponse.getApplicationId().toString(),
+          services.getCertificateMaterializer(), services.getSettings().getHopsRpcTls());
+    }
   
     StringBuilder tmpBuilder = new StringBuilder();
     for (Map.Entry<String, String> prop : jobSystemProperties.entrySet()) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/jobhistory/JobState.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/jobhistory/JobState.java
@@ -38,7 +38,8 @@ public enum JobState {
   AGGREGATING_LOGS("Aggregating logs"),
   FRAMEWORK_FAILURE("Framework failure"),
   STARTING_APP_MASTER("Starting Application Master"),
-  APP_MASTER_START_FAILED("Failed starting AM");
+  APP_MASTER_START_FAILED("Failed starting AM"),
+  GENERATING_CERTS("Generating certificate");
 
   private final String readable;
 
@@ -69,6 +70,8 @@ public enum JobState {
         return JobState.NEW_SAVING;
       case SUBMITTED:
         return JobState.SUBMITTED;
+      case GENERATING_CERTS:
+        return JobState.GENERATING_CERTS;
       default:
         throw new IllegalArgumentException("Invalid enum constant"); // can never happen        
     }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -21,7 +21,6 @@
 package io.hops.hopsworks.common.jobs.spark;
 
 import io.hops.hopsworks.common.dao.jobs.description.Jobs;
-import io.hops.hopsworks.common.exception.CryptoPasswordNotFoundException;
 import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
 import io.hops.hopsworks.common.jobs.AsynchronousJobExecutor;
 import io.hops.hopsworks.common.jobs.jobhistory.JobType;
@@ -134,17 +133,6 @@ public class SparkYarnRunnerBuilder {
     builder.setYarnClient(yarnClient);
     builder.setDfsClient(dfsClient);
     builder.setJobUser(jobUser);
-    if (settings.getHopsRpcTls()) {
-      try {
-        String password = services.getBaseHadoopClientsService()
-            .getProjectSpecificUserCertPassword(jobUser);
-        builder.setKeyStorePassword(password);
-        builder.setTrustStorePassword(password);
-      } catch (CryptoPasswordNotFoundException ex) {
-        LOG.log(Level.SEVERE, ex.getMessage(), ex);
-        throw new IOException(ex);
-      }
-    }
     
     /*** 1. Set stagingPath ***/
     

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -887,16 +887,13 @@ public class CertificateMaterializer {
             writeToHDFS(dfso, trustStore, material.getKeyStore().array());
             dfso.setOwner(trustStore, ownerName, groupName);
             dfso.setPermission(trustStore, permissions);
-            
-            // If RPC TLS is enabled, password file is injected automatically by the NodeManager
-            if (!settings.getHopsRpcTls()) {
-              Path passwordFile = new Path(remoteDirectory + Path.SEPARATOR + key.getExtendedUsername()
-                  + CERT_PASS_SUFFIX);
-              writeToHDFS(dfso, passwordFile, new String(material.getPassword()));
-              dfso.setOwner(passwordFile, ownerName, groupName);
-              dfso.setPermission(passwordFile, permissions);
-            }
-            
+  
+            Path passwordFile = new Path(remoteDirectory + Path.SEPARATOR + key.getExtendedUsername()
+                + CERT_PASS_SUFFIX);
+            writeToHDFS(dfso, passwordFile, new String(material.getPassword()));
+            dfso.setOwner(passwordFile, ownerName, groupName);
+            dfso.setPermission(passwordFile, permissions);
+  
             // Cache should be flushed otherwise NN will raise permission exceptions
             dfso.flushCache(ownerName, groupName);
           } finally {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificatesMgmService.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificatesMgmService.java
@@ -72,6 +72,8 @@ import java.util.logging.Logger;
 public class CertificatesMgmService {
   private final Logger LOG = Logger.getLogger(CertificatesMgmService.class.getName());
   
+  public static final String CERTIFICATE_SUFFIX = ".cert.pem";
+  
   @EJB
   private Settings settings;
   @EJB


### PR DESCRIPTION
[HOPSWORKS-542]  Add REST endpoint for revoking application certificates and refactor signing csr

[HOPSWORKS-542]  Comment-out adding crypto material as local resources for Spark

[HOPSWORKS-542]  Remove adding user's crypto material as local resources of a container if Hops RPC TLS is enabled

[HOPSWORKS-542]  Fix bug in Jupyter config generator with Spark local resources list

[HOPSWORKS-542]  Change the authentication mechanism with user submitted keystore

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-542

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
