### PR TITLE
HOPSWORKS-570

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/hopssite/dto/LocalDatasetHelper.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/hopssite/dto/LocalDatasetHelper.java
@@ -23,7 +23,6 @@ package io.hops.hopsworks.api.hopssite.dto;
 import io.hops.hopsworks.common.dao.dataset.Dataset;
 import io.hops.hopsworks.common.dataset.DatasetController;
 import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +39,7 @@ public class LocalDatasetHelper {
       long size;
         //TODO Alex - if we want to still get size, it should either be immutable for dataset, 
         //or updated periodically into the db and provide this approximate version when requested
-        size = -1;
+      size = -1;
 //        size = dfso.getLastUpdatedDatasetSize(path);
       localDS.add(new LocalDatasetDTO(d.getInodeId(), d.getName(), d.getDescription(), d.getProject().getName(), date,
         date, size));

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/hopssite/dto/LocalDatasetHelper.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/hopssite/dto/LocalDatasetHelper.java
@@ -38,11 +38,10 @@ public class LocalDatasetHelper {
       Date date = new Date(d.getInode().getModificationTime().longValue());
       Path path = datasetCtrl.getDatasetPath(d);
       long size;
-      try {
-        size = dfso.getLastUpdatedDatasetSize(path);
-      } catch (IOException ex) {
+        //TODO Alex - if we want to still get size, it should either be immutable for dataset, 
+        //or updated periodically into the db and provide this approximate version when requested
         size = -1;
-      }
+//        size = dfso.getLastUpdatedDatasetSize(path);
       localDS.add(new LocalDatasetDTO(d.getInodeId(), d.getName(), d.getDescription(), d.getProject().getName(), date,
         date, size));
     }

--- a/hopsworks-web/yo/app/scripts/controllers/delaclusterDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/delaclusterDatasetCtrl.js
@@ -217,6 +217,9 @@ angular.module('hopsWorksApp')
               if (fileSizeInBytes === undefined) {
                 return '--';
               }
+              if (fileSizeInBytes === -1) {
+                return '--';
+              }
               return convertSize(fileSizeInBytes);
             };
 


### PR DESCRIPTION
Temporarily disable dataset set in cluster dataset listing.
This should once again make the listing usable.
Future work - consider immutable datasets and size save in db or mutable datasets with size being recomputed periodically in the db and providing this stale value on listings.