### PR TITLE
[HOPSWORKS-581] Add missing HADOOP_HDFS_HOME variable in kernel_template.json

### DIFF
--- a/hopsworks-common/src/main/resources/io/hops/jupyter/kernel_template.json
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/kernel_template.json
@@ -10,8 +10,8 @@
   ],
   "env": {
     "HADOOP_HOME": "%%hadoop_home%%",
+    "HADOOP_HDFS_HOME": "%%hadoop_home%%",
     "HADOOP_CONF_DIR": "%%hadoop_home%%/etc/hadoop",
-    "LIBHDFS_OPTS": "-Xmx96m",
     "PDIR": "%%secret_dir%%",
     "HADOOP_USER_NAME": "%%hdfs_user%%",     
     "LIBHDFS_OPTS": "-Xmx96m",


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
