### PR TITLE
[HOPSWORKS-611] Unset MetaEnabled on the dataset before deleting to a…

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dataset/DatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dataset/DatasetController.java
@@ -49,6 +49,7 @@ import io.hops.hopsworks.common.util.Settings;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -299,8 +300,8 @@ public class DatasetController {
   public boolean deleteDatasetDir(Dataset dataset, Path location,
       DistributedFileSystemOps udfso) throws IOException {
     OperationsLog log = new OperationsLog(dataset, OperationType.Delete);
-    boolean success;
-    success = udfso.rm(location, true);
+    udfso.unsetMetaEnabled(location);
+    boolean success = udfso.rm(location, true);
     if (success) {
       operationsLogFacade.persist(log);
     }
@@ -576,4 +577,15 @@ public class DatasetController {
     }
     return false;
   }
+  
+  public void unsetMetaEnabledForAllDatasets(DistributedFileSystemOps dfso, Project project) throws IOException {
+    Collection<Dataset> datasets = project.getDatasetCollection();
+    for (Dataset dataset : datasets) {
+      if (dataset.isSearchable() && !dataset.isShared()) {
+        Path dspath = getDatasetPath(dataset);
+        dfso.unsetMetaEnabled(dspath);
+      }
+    }
+  }
+  
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFileSystemOps.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/DistributedFileSystemOps.java
@@ -587,9 +587,29 @@ public class DistributedFileSystemOps {
    */
   public void setMetaEnabled(String location) throws IOException {
     Path path = new Path(location);
+    setMetaEnabled(path);
+  }
+  
+  /**
+   * Marks a file/folder in location as metadata enabled
+   * <p/>
+   * @param path
+   * @throws IOException
+   */
+  public void setMetaEnabled(Path path) throws IOException {
     this.dfs.setMetaEnabled(path, true);
   }
 
+  /**
+   * Unset Metadata enabled flag on a given path
+   * <p/>
+   * @param path
+   * @throws IOException
+   */
+  public void unsetMetaEnabled(Path path) throws IOException {
+    this.dfs.setMetaEnabled(path, false);
+  }
+  
   /**
    * Returns the number of blocks of a file in the given path.
    * The path has to resolve to a file.

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
@@ -389,6 +389,8 @@ public class ProjectController {
       }
       LOGGER.log(Level.FINE, "PROJECT CREATION TIME. Step 8 (logs): {0}", System.currentTimeMillis() - startTime);
 
+      logProject(project, OperationType.Add);
+      
       // enable services
       for (ProjectServiceEnum service : projectServices) {
         try {
@@ -428,8 +430,6 @@ public class ProjectController {
             + "generation thread to finish. Will try to cleanup...", ex);
         cleanup(project, sessionId, certsGenerationFuture);
       }
-      
-      logProject(project, OperationType.Add);
       
       return project;
 
@@ -955,7 +955,7 @@ public class ProjectController {
       throw new AppException(Response.Status.BAD_REQUEST.getStatusCode(),
           ResponseMessages.PROJECT_REMOVAL_NOT_ALLOWED);
     }
-
+    
     cleanup(project, sessionId);
     
     certificateMaterializer.forceRemoveLocalMaterial(user.getUsername(), project.getName(), null, true);
@@ -1534,7 +1534,9 @@ public class ProjectController {
     DistributedFileSystemOps dfso = null;
     try {
       dfso = dfs.getDfsOps();
-
+      
+      datasetController.unsetMetaEnabledForAllDatasets(dfso, project);
+      
       //log removal to notify elastic search
       logProject(project, OperationType.Delete);
       //change the owner and group of the project folder to hdfs super user


### PR DESCRIPTION
…void redundant calls to Elasticsearch

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPSWORKS-611

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**
Unset the meta enabled flag on the datasets before deleting to avoid duplicate calls to elasticsearch

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
Testing: https://github.com/hopshadoop/hops-testing/pull/127